### PR TITLE
docs: update API doc links to real URLs for proper redirection

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-English | [中文](API.zh-CN.md)
+English | [中文](https://github.com/AGenUI/AGenUI/blob/main/docs/API.zh-CN.md)
 
 ## Core API
 
@@ -823,5 +823,4 @@ AGenUI.setDayNightMode('dark');
 
 ## Related Links
 
-- [QuickStart](./QuickStart.md)
-- [Project Structure](./PROJECT_STRUCTURE.md)
+- [QuickStart](https://github.com/AGenUI/AGenUI/blob/main/docs/QuickStart.md)

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -1,6 +1,6 @@
 # API 参考
 
-[English](API.md) | 中文
+[English](https://github.com/AGenUI/AGenUI/blob/main/docs/API.md) | 中文
 
 ## 核心 API
 
@@ -823,5 +823,4 @@ AGenUI.setDayNightMode('dark');
 
 ## 相关链接
 
-- [快速上手](./QuickStart.zh-CN.md)
-- [项目结构说明](./PROJECT_STRUCTURE.zh-CN.md)
+- [快速上手](https://github.com/AGenUI/AGenUI/blob/main/docs/QuickStart.zh-CN.md)


### PR DESCRIPTION
Update to real URLs, so that the links can redirect normally when the official site references this document.