### PR TITLE
fix(harmony): make Lottie measurer Sync to prevent 0x0 rendering

### DIFF
--- a/playground/harmony/entry/src/main/ets/components/LottieMeasurementComponent.ets
+++ b/playground/harmony/entry/src/main/ets/components/LottieMeasurementComponent.ets
@@ -4,9 +4,18 @@ import { MeasureResult } from '@agenui/agenui';
 /**
  * Lottie component measurement class
  *
- * Lottie animation is an async loading component; width and height are determined by Yoga layout constraints.
- * - calcType=1 (Async): Returns placeholder {0, 0} first, triggers re-measurement via markDirty after animation loading completes.
- * - When Yoga passes Exactly/AtMost constraints, use constraint values directly; use DEFAULT_SIZE fallback when unconstrained.
+ * Lottie animation has no intrinsic natural size exposed by lottie-turbo before
+ * the animation JSON is loaded, and CustomLottieComponent does not call
+ * reportContentHeight after load. So this measurer always returns Sync with a
+ * deterministic placeholder so Yoga can size the node up-front:
+ *   - When Yoga passes Exactly/AtMost constraints, use the constraint value.
+ *   - Otherwise fall back to DEFAULT_SIZE (matches buildCustomLottie's 200 default).
+ *
+ * Why Sync instead of Async:
+ *   The engine in core/.../agenui_virtual_dom_node.cpp drops the measurer's
+ *   width/height entirely when calcType == Async and returns {0,0} to Yoga,
+ *   relying on a later reportContentHeight call to mark the node dirty. Since
+ *   no such call is made for Lottie, Async would leave the node at 0x0 forever.
  *
  * Corresponds to buildCustomLottie:
  *   .width(getViewWidth()  <= 0 ? 200 : getViewWidth())
@@ -32,8 +41,7 @@ export class LottieMeasurementComponent extends MeasurementComponent {
       ? maxHeight
       : LottieMeasurementComponent.DEFAULT_SIZE;
 
-    // calcType=1: Async, Yoga uses this size as placeholder first, markDirty triggers re-layout after animation loading completes
-    const result: MeasureResult = { width: w, height: h, calcType: 1 };
+    const result: MeasureResult = { width: w, height: h, calcType: 0 };
     return result;
   }
 }


### PR DESCRIPTION
Switch LottieMeasurementComponent from calcType=1 (Async) to calcType=0 (Sync) so Yoga uses the measured width/height directly. Async mode causes the engine to discard the measurer result and wait for reportContentHeight, which CustomLottieComponent never calls, leaving Lottie nodes at 0x0 and invisible on screen.

## Description

<!-- Brief description of what this PR does and why -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [ ] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [ ] Code compiles without errors on affected platform(s)
- [ ] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)