### PR TITLE
fix(harmony):Fix memory leak issues during measurement

### DIFF
--- a/platforms/harmony/agenui/src/main/cpp/a2ui/measure/hm_text_measure_utils.h
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/measure/hm_text_measure_utils.h
@@ -361,6 +361,9 @@ public:
         OH_Drawing_DestroyTypography(typography);
         OH_Drawing_DestroyTypographyHandler(handler);
         OH_Drawing_DestroyTypographyStyle(typoStyle);
+        if (fontCollection) {
+            OH_Drawing_DestroyFontCollection(fontCollection);
+        }
 
         return result;
     }


### PR DESCRIPTION
## Description

Fix memory leak issue. After layout formatting is complete, font manager must be destroyed and released promptly; otherwise, memory leaks will occur.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [x] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] Code compiles without errors on affected platform(s)
- [x] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)