### PR TITLE
feat: add Go Agent SDK and rizzcharts sample via subtree

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -128,6 +128,22 @@ The following libraries are included under the Apache License, Version 2.0
     Copyright (c) 2017-2019 Dimitry Ivanov (noties)
 
 --------------------------------------------------------------------------------
+AGenUI Go Agent SDK
+--------------------------------------------------------------------------------
+
+  Copyright (c) 2026 AGenUI Contributors
+
+  The Go Agent SDK (agent_sdks/go/) and Go samples (samples/go/) were
+  originally authored by AGenUI Contributors and imported via git subtree
+  from the upstream google/A2UI repository. The source code carries the
+  Google LLC copyright header as required by the Google CLA, while the
+  original authorship and copyright are retained by AGenUI Contributors
+  under the Apache License, Version 2.0.
+
+  Upstream source: https://github.com/google/A2UI
+  License: Apache 2.0
+
+--------------------------------------------------------------------------------
 Disclaimer
 --------------------------------------------------------------------------------
 

--- a/agent_sdks/go/README.md
+++ b/agent_sdks/go/README.md
@@ -1,0 +1,82 @@
+# A2UI Go Agent SDK
+
+[中文文档](README.zh-CN.md)
+
+The `agent_sdks/go` directory contains the Go implementation of the A2UI agent SDK.
+
+## What is the A2UI Go Agent SDK?
+
+The A2UI (Agent-to-UI) protocol defines a standard way for AI agents to generate rich, interactive user interfaces. This Go SDK enables server-side agents to:
+
+- **Generate structured UI responses** — produce A2UI protocol messages (createSurface, updateComponents, updateDataModel, deleteSurface) that any compliant renderer (Android, iOS, HarmonyOS, Web) can display.
+- **Stream UI incrementally** — parse and yield partial UI components in real time as the LLM generates tokens, enabling low-latency progressive rendering.
+- **Validate output** — check A2UI messages against JSON schemas and protocol rules (topology, reachability, circular references, recursion depth) to catch errors before they reach the client.
+- **Manage component catalogs** — load built-in or custom catalogs and generate LLM system prompts that teach the model which UI components are available and how to use them.
+
+In short, it is the bridge between an LLM backend and any A2UI-compatible front-end renderer.
+
+## Installation
+
+```bash
+go get github.com/AGenUI/AGenUI/agent_sdks/go
+```
+
+## Usage
+
+For a complete working example, see the [Rizzcharts sample](../../samples/go/rizzcharts/).
+
+## Core Components
+
+### Package `a2ui` (root)
+
+* **`a2ui.go`**: Package entry point. Defines `Version`, `SystemPromptOptions`,
+  and the `InferenceStrategy` interface for generating LLM system prompts.
+
+### Schema Management (`schema/`)
+
+* **`manager.go`**: The `A2uiSchemaManager` handles loading specification
+  schemas, managing catalogs, and generating system prompts for LLMs.
+* **`validator.go`**: Implements `A2uiValidator` for validating A2UI messages
+  against JSON schemas and protocol rules (topology, reachability, circular
+  references, recursion depth).
+* **`catalog.go`**: Defines `A2uiCatalog` and `CatalogConfig` for handling
+  component libraries.
+* **`catalog_provider.go`**: Provides `A2uiCatalogProvider` interface with
+  `FileSystemCatalogProvider` and `RawCatalogProvider` implementations.
+* **`common_modifiers.go`**: Schema modifier utilities for pruning and
+  customizing component schemas.
+* **`assets.go`**: Bundled JSON schema resources (embedded via `go:embed`).
+* **`utils.go`**: Shared utility functions for topology analysis and ref field
+  extraction.
+
+### Parser (`parser/`)
+
+* **`parser.go`**: Implementation of `ParseResponse` for synchronous parsing of
+  complete LLM responses.
+* **`streaming.go`**: `A2uiStreamParser` for incremental streaming parsing with
+  automatic JSON healing, component-level yielding, and validation.
+* **`streaming_v09.go`**: v0.9-specific streaming parser logic
+  (`createSurface`, `updateComponents`, `updateDataModel`, `deleteSurface`).
+* **`payload_fixer.go`**: Utilities to automatically correct common LLM output
+  issues in A2UI payloads (trailing commas, unquoted keys, etc.).
+* **`response_part.go`**: Defines the `ResponsePart` struct representing parsed
+  output (text + A2UI JSON).
+
+### Basic Catalog (`basiccatalog/`)
+
+* **`basiccatalog.go`**: Implementation of `BundledCatalogProvider` for the
+  standard A2UI basic catalog (Button, Text, Row, Column, etc.).
+
+## Running Tests
+
+1. Navigate to the directory:
+
+   ```bash
+   cd agent_sdks/go
+   ```
+
+2. Run all tests:
+
+   ```bash
+   go test ./...
+   ```

--- a/agent_sdks/go/README.zh-CN.md
+++ b/agent_sdks/go/README.zh-CN.md
@@ -1,0 +1,68 @@
+# A2UI Go Agent SDK
+
+[English](README.md)
+
+`agent_sdks/go` 目录包含 A2UI Agent SDK 的 Go 语言实现。
+
+## A2UI Go Agent SDK 是什么？
+
+A2UI（Agent-to-UI）协议定义了一套标准，让 AI Agent 能够生成富交互式用户界面。这个 Go SDK 使服务端 Agent 能够：
+
+- **生成结构化 UI 响应** — 产出符合 A2UI 协议的消息（createSurface、updateComponents、updateDataModel、deleteSurface），可被任何合规的渲染器（Android、iOS、HarmonyOS、Web）直接展示。
+- **流式增量解析** — 在 LLM 逐 token 生成的过程中，实时解析并产出部分 UI 组件，实现低延迟的渐进式渲染。
+- **校验输出** — 对 A2UI 消息进行 JSON Schema 校验和协议规则检查（拓扑结构、可达性、循环引用、递归深度），在到达客户端之前捕获错误。
+- **管理组件 Catalog** — 加载内置或自定义的组件目录，自动生成 LLM system prompt，告知模型有哪些可用的 UI 组件及其用法。
+
+简而言之，它是 LLM 后端与任意 A2UI 兼容前端渲染器之间的桥梁。
+
+## 安装
+
+```bash
+go get github.com/AGenUI/AGenUI/agent_sdks/go
+```
+
+## 使用方法
+
+完整的使用示例请参考 [Rizzcharts 示例](../../samples/go/rizzcharts/)。
+
+## 核心组件
+
+### 根包 `a2ui`
+
+* **`a2ui.go`**：包入口。定义 `Version`、`SystemPromptOptions` 以及用于生成 LLM 系统提示词的 `InferenceStrategy` 接口。
+
+### Schema 管理 (`schema/`)
+
+* **`manager.go`**：`A2uiSchemaManager` 负责加载规范 schema、管理组件目录、为 LLM 生成系统提示词。
+* **`validator.go`**：`A2uiValidator` 对 A2UI 消息进行 JSON Schema 校验和协议规则检查（拓扑结构、可达性、循环引用、递归深度）。
+* **`catalog.go`**：`A2uiCatalog` 和 `CatalogConfig`，用于管理组件库。
+* **`catalog_provider.go`**：`A2uiCatalogProvider` 接口，提供 `FileSystemCatalogProvider` 和 `RawCatalogProvider` 实现。
+* **`common_modifiers.go`**：Schema 修改器工具，用于裁剪和定制组件 schema。
+* **`assets.go`**：通过 `go:embed` 打包的 JSON Schema 资源。
+* **`utils.go`**：拓扑分析和 ref 字段提取的共享工具函数。
+
+### 解析器 (`parser/`)
+
+* **`parser.go`**：`ParseResponse` 用于同步解析完整的 LLM 响应。
+* **`streaming.go`**：`A2uiStreamParser` 流式增量解析器，支持 JSON 自动修复、组件级别的增量输出和校验。
+* **`streaming_v09.go`**：v0.9 版本的流式解析逻辑（`createSurface`、`updateComponents`、`updateDataModel`、`deleteSurface`）。
+* **`payload_fixer.go`**：自动修复 LLM 输出中常见的 JSON 问题（尾逗号、未引用的 key 等）。
+* **`response_part.go`**：`ResponsePart` 结构体，表示解析后的输出（文本 + A2UI JSON）。
+
+### 基础组件目录 (`basiccatalog/`)
+
+* **`basiccatalog.go`**：`BundledCatalogProvider`，提供标准 A2UI 基础组件目录（Button、Text、Row、Column 等）。
+
+## 运行测试
+
+1. 进入目录：
+
+   ```bash
+   cd agent_sdks/go
+   ```
+
+2. 运行所有测试：
+
+   ```bash
+   go test ./...
+   ```

--- a/agent_sdks/go/a2ui.go
+++ b/agent_sdks/go/a2ui.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package a2ui provides the Go SDK for A2UI (Agent-to-UI) protocol.
+package a2ui
+
+// Version is the current version of the A2UI Go SDK.
+const Version = "0.2.2"
+
+// SystemPromptOptions holds the parameters for generating a system prompt.
+type SystemPromptOptions struct {
+	// RoleDescription describes the agent's role.
+	RoleDescription string
+	// WorkflowDescription describes the workflow.
+	WorkflowDescription string
+	// UIDescription describes the UI.
+	UIDescription string
+	// ClientUICapabilities are capabilities reported by the client for targeted schema pruning.
+	ClientUICapabilities map[string]any
+	// AllowedComponents is the list of allowed catalog components.
+	AllowedComponents []string
+	// AllowedMessages is the list of allowed messages.
+	AllowedMessages []string
+	// IncludeSchema controls whether to include the schema.
+	IncludeSchema bool
+	// IncludeExamples controls whether to include examples.
+	IncludeExamples bool
+	// ValidateExamples controls whether to validate examples.
+	ValidateExamples bool
+}
+
+// InferenceStrategy generates system prompts for all LLM requests.
+type InferenceStrategy interface {
+	// GenerateSystemPrompt generates a system prompt based on the given options.
+	GenerateSystemPrompt(opts SystemPromptOptions) string
+}

--- a/agent_sdks/go/basiccatalog/basiccatalog.go
+++ b/agent_sdks/go/basiccatalog/basiccatalog.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package basiccatalog provides the bundled basic A2UI catalog.
+package basiccatalog
+
+import (
+	"github.com/AGenUI/AGenUI/agent_sdks/go/schema"
+)
+
+// BasicCatalogName is the name of the basic catalog.
+const BasicCatalogName = "basic"
+
+// BasicCatalogPaths maps version to the relative path of the basic catalog schema.
+var BasicCatalogPaths = map[string]map[string]string{
+	schema.Version09: {
+		schema.CatalogSchemaKey: "specification/v0_9/json/basic_catalog.json",
+	},
+}
+
+// BundledCatalogProvider loads schemas from bundled package resources.
+type BundledCatalogProvider struct {
+	Version string
+}
+
+// Load loads the basic catalog schema from bundled resources.
+func (p *BundledCatalogProvider) Load() (map[string]any, error) {
+	resource, err := schema.LoadFromBundledResource(p.Version, schema.CatalogSchemaKey, BasicCatalogPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	// Post-load processing for catalogs.
+	if _, ok := resource[schema.CatalogIDKey]; !ok {
+		specMap, ok := BasicCatalogPaths[p.Version]
+		if ok {
+			if relPath, ok := specMap[schema.CatalogSchemaKey]; ok {
+				resource[schema.CatalogIDKey] = schema.BaseSchemaURL + relPath
+			}
+		}
+	}
+
+	if _, ok := resource["$schema"]; !ok {
+		resource["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+	}
+
+	return resource, nil
+}
+
+// GetConfig returns a CatalogConfig for the basic bundled catalog.
+func GetConfig(version string, examplesPath string) schema.CatalogConfig {
+	return schema.CatalogConfig{
+		Name:         BasicCatalogName,
+		Provider:     &BundledCatalogProvider{Version: version},
+		ExamplesPath: examplesPath,
+	}
+}

--- a/agent_sdks/go/go.mod
+++ b/agent_sdks/go/go.mod
@@ -1,0 +1,10 @@
+module github.com/AGenUI/AGenUI/agent_sdks/go
+
+go 1.22
+
+require (
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require golang.org/x/text v0.14.0 // indirect

--- a/agent_sdks/go/go.sum
+++ b/agent_sdks/go/go.sum
@@ -1,0 +1,10 @@
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/agent_sdks/go/parser/conformance_test.go
+++ b/agent_sdks/go/parser/conformance_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/AGenUI/AGenUI/agent_sdks/go/schema"
+	"gopkg.in/yaml.v3"
+)
+
+// ---------------------------------------------------------------------------
+// YAML types
+// ---------------------------------------------------------------------------
+
+type conformanceCatalogConfig struct {
+	Version           string `yaml:"version"`
+	S2CSchema         any    `yaml:"s2c_schema"`
+	CatalogSchema     any    `yaml:"catalog_schema"`
+	CommonTypesSchema any    `yaml:"common_types_schema"`
+}
+
+type parserConformanceCase struct {
+	Name         string                   `yaml:"name"`
+	Catalog      conformanceCatalogConfig `yaml:"catalog"`
+	ProcessChunk []struct {
+		Input       string `yaml:"input"`
+		Expect      []any  `yaml:"expect"`
+		ExpectError string `yaml:"expect_error"`
+	} `yaml:"process_chunk"`
+}
+
+type validatorConformanceCase struct {
+	Name     string                   `yaml:"name"`
+	Catalog  conformanceCatalogConfig `yaml:"catalog"`
+	Validate []struct {
+		Payload     any    `yaml:"payload"`
+		ExpectError string `yaml:"expect_error"`
+	} `yaml:"validate"`
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func conformancePath(filename string) string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "conformance", filename)
+}
+
+func loadConformanceJSON(filename string) (map[string]any, error) {
+	data, err := os.ReadFile(conformancePath(filename))
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	return result, json.Unmarshal(data, &result)
+}
+
+// remapSchemaRefs rewrites $ref values so that conformance-specific
+// filenames (e.g. simplified_catalog_v09.json) are mapped to the
+// canonical names the Go validator registers (catalog.json, etc.).
+func remapSchemaRefs(obj any) any {
+	renames := map[string]string{
+		"simplified_s2c_v09.json":          "server_to_client.json",
+		"simplified_s2c_v08.json":          "server_to_client.json",
+		"simplified_catalog_v09.json":      "catalog.json",
+		"simplified_catalog_v08.json":      "catalog.json",
+		"simplified_common_types_v09.json": "common_types.json",
+	}
+
+	switch v := obj.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, val := range v {
+			if k == "$ref" {
+				if s, ok := val.(string); ok {
+					for old, repl := range renames {
+						s = strings.Replace(s, old, repl, 1)
+					}
+					out[k] = s
+				} else {
+					out[k] = val
+				}
+			} else {
+				out[k] = remapSchemaRefs(val)
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = remapSchemaRefs(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func setupConformanceCatalog(t *testing.T, cfg conformanceCatalogConfig) *schema.A2uiCatalog {
+	t.Helper()
+	load := func(raw any) map[string]any {
+		switch v := raw.(type) {
+		case string:
+			m, err := loadConformanceJSON(v)
+			if err != nil {
+				t.Fatalf("load schema %s: %v", v, err)
+			}
+			return remapSchemaRefs(m).(map[string]any)
+		case map[string]any:
+			return v
+		}
+		return map[string]any{}
+	}
+
+	s2c := load(cfg.S2CSchema)
+	cat := load(cfg.CatalogSchema)
+	ct := load(cfg.CommonTypesSchema)
+
+	if cat == nil {
+		cat = map[string]any{"catalogId": "test_catalog", "components": map[string]any{}}
+	}
+	if ct == nil {
+		ct = map[string]any{}
+	}
+
+	// Ensure inline catalog schemas have necessary $defs so that the eager
+	// Go jsonschema compiler can resolve all $ref pointers.
+	if cfg.Version == schema.Version09 {
+		defs, _ := cat["$defs"].(map[string]any)
+		if defs == nil {
+			defs = map[string]any{}
+			cat["$defs"] = defs
+		}
+		stubs := map[string]map[string]any{
+			"anyComponent":           {},
+			"CatalogComponentCommon": {"type": "object"},
+		}
+		for k, v := range stubs {
+			if _, exists := defs[k]; !exists {
+				defs[k] = v
+			}
+		}
+	}
+
+	return &schema.A2uiCatalog{
+		Version:           cfg.Version,
+		Name:              "test_catalog",
+		S2CSchema:         s2c,
+		CommonTypesSchema: ct,
+		CatalogSchema:     cat,
+	}
+}
+
+// normalizeValue round-trips through JSON so YAML int → float64, etc.
+func normalizeValue(v any) any {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return v
+	}
+	var out any
+	_ = json.Unmarshal(data, &out)
+	return out
+}
+
+func partsToSerializable(parts []ResponsePart) []any {
+	out := make([]any, len(parts))
+	for i, p := range parts {
+		m := map[string]any{}
+		if p.Text != "" {
+			m["text"] = p.Text
+		}
+		if p.A2UIJSON != nil {
+			m["a2ui"] = p.A2UIJSON
+		}
+		out[i] = m
+	}
+	return out
+}
+
+func assertPartsMatch(t *testing.T, step int, actual []ResponsePart, expected []any) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		aj, _ := json.MarshalIndent(partsToSerializable(actual), "", "  ")
+		ej, _ := json.MarshalIndent(expected, "", "  ")
+		t.Fatalf("step %d: got %d parts, want %d\n  actual:   %s\n  expected: %s",
+			step, len(actual), len(expected), aj, ej)
+	}
+	for i, part := range actual {
+		exp, ok := expected[i].(map[string]any)
+		if !ok {
+			t.Fatalf("step %d, part[%d]: expected is %T, want map", step, i, expected[i])
+		}
+
+		wantText, _ := exp["text"].(string)
+		if part.Text != wantText {
+			t.Errorf("step %d, part[%d].Text = %q, want %q", step, i, part.Text, wantText)
+		}
+
+		if a2ui, has := exp["a2ui"]; has {
+			if part.A2UIJSON == nil {
+				t.Errorf("step %d, part[%d].A2UIJSON is nil, want %v", step, i, a2ui)
+				continue
+			}
+			aN := normalizeValue(part.A2UIJSON)
+			eN := normalizeValue(a2ui)
+			if !reflect.DeepEqual(aN, eN) {
+				aj, _ := json.MarshalIndent(aN, "      ", "  ")
+				ej, _ := json.MarshalIndent(eN, "      ", "  ")
+				t.Errorf("step %d, part[%d].A2UIJSON mismatch:\n      got:  %s\n      want: %s",
+					step, i, aj, ej)
+			}
+		} else if part.A2UIJSON != nil {
+			t.Errorf("step %d, part[%d].A2UIJSON = %v, want nil", step, i, part.A2UIJSON)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parser conformance
+// ---------------------------------------------------------------------------
+
+func TestParserConformance(t *testing.T) {
+	data, err := os.ReadFile(conformancePath("parser.yaml"))
+	if err != nil {
+		t.Fatalf("read parser.yaml: %v", err)
+	}
+	var cases []parserConformanceCase
+	if err := yaml.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("parse parser.yaml: %v", err)
+	}
+
+	for _, tc := range cases {
+		if tc.Catalog.Version != schema.Version09 {
+			continue // Go SDK only supports v0.9
+		}
+		t.Run(tc.Name, func(t *testing.T) {
+			catalog := setupConformanceCatalog(t, tc.Catalog)
+			p := NewA2uiStreamParser(catalog)
+
+			for si, step := range tc.ProcessChunk {
+				parts, err := p.ProcessChunk(step.Input)
+
+				if step.ExpectError != "" {
+					if err == nil {
+						t.Errorf("step %d: expected error %q, got nil", si, step.ExpectError)
+					} else {
+						errLower := strings.ToLower(err.Error())
+						expLower := strings.ToLower(step.ExpectError)
+						re, reErr := regexp.Compile("(?i)" + step.ExpectError)
+						if reErr != nil {
+							if !strings.Contains(errLower, expLower) {
+								t.Errorf("step %d: error %q doesn't contain %q", si, err.Error(), step.ExpectError)
+							}
+						} else if !re.MatchString(err.Error()) {
+							t.Errorf("step %d: error %q doesn't match /%s/", si, err.Error(), step.ExpectError)
+						}
+					}
+					continue
+				}
+
+				if err != nil {
+					t.Fatalf("step %d: unexpected error: %v (input: %q)", si, err, step.Input)
+				}
+
+				assertPartsMatch(t, si, parts, step.Expect)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validator conformance
+// ---------------------------------------------------------------------------
+
+func TestValidatorConformance(t *testing.T) {
+	data, err := os.ReadFile(conformancePath("validator.yaml"))
+	if err != nil {
+		t.Fatalf("read validator.yaml: %v", err)
+	}
+	var cases []validatorConformanceCase
+	if err := yaml.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("parse validator.yaml: %v", err)
+	}
+
+	for _, tc := range cases {
+		if tc.Catalog.Version != schema.Version09 {
+			continue // Go SDK only supports v0.9
+		}
+		t.Run(tc.Name, func(t *testing.T) {
+			catalog := setupConformanceCatalog(t, tc.Catalog)
+			validator := schema.NewA2uiValidator(catalog)
+
+			for ci, vc := range tc.Validate {
+				// Normalize the YAML payload through JSON for type consistency.
+				payload := normalizeValue(vc.Payload)
+
+				vErr := validator.Validate(payload, "", true)
+
+				if vc.ExpectError != "" {
+					if vErr == nil {
+						t.Errorf("case %d: expected error %q, got nil", ci, vc.ExpectError)
+					} else {
+						errLower := strings.ToLower(vErr.Error())
+						expLower := strings.ToLower(vc.ExpectError)
+						re, reErr := regexp.Compile("(?i)" + vc.ExpectError)
+						if reErr != nil {
+							if !strings.Contains(errLower, expLower) {
+								t.Errorf("case %d: error %q doesn't contain %q", ci, vErr.Error(), vc.ExpectError)
+							}
+						} else if !re.MatchString(vErr.Error()) {
+							t.Errorf("case %d: error %q doesn't match /%s/", ci, vErr.Error(), vc.ExpectError)
+						}
+					}
+				} else {
+					if vErr != nil {
+						t.Errorf("case %d: unexpected error: %v", ci, vErr)
+					}
+				}
+			}
+		})
+	}
+}

--- a/agent_sdks/go/parser/constants.go
+++ b/agent_sdks/go/parser/constants.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package parser provides A2UI response parsing utilities.
+package parser
+
+// Default root ID.
+const DefaultRootID = "root"
+
+// Message types (v0.9).
+const (
+	MsgTypeCreateSurface    = "createSurface"
+	MsgTypeUpdateComponents = "updateComponents"
+	MsgTypeUpdateDataModel  = "updateDataModel"
+	MsgTypeDeleteSurface    = "deleteSurface"
+)

--- a/agent_sdks/go/parser/logger.go
+++ b/agent_sdks/go/parser/logger.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"io"
+	"log"
+)
+
+// logger is the package-level logger. It defaults to discarding all output.
+// Use SetLogger to enable logging.
+var logger = log.New(io.Discard, "[a2ui-parser] ", log.LstdFlags)
+
+// SetLogger sets the logger used by the parser package.
+// Pass nil to disable logging.
+func SetLogger(l *log.Logger) {
+	if l == nil {
+		logger = log.New(io.Discard, "[a2ui-parser] ", log.LstdFlags)
+		return
+	}
+	logger = l
+}

--- a/agent_sdks/go/parser/parser.go
+++ b/agent_sdks/go/parser/parser.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/AGenUI/AGenUI/agent_sdks/go/schema"
+)
+
+// a2uiBlockPattern matches content between <a2ui-json> and </a2ui-json> tags.
+var a2uiBlockPattern = regexp.MustCompile(
+	`(?s)` + regexp.QuoteMeta(schema.A2UIOpenTag) + `(.*?)` + regexp.QuoteMeta(schema.A2UICloseTag),
+)
+
+// HasA2UIParts checks if the content has A2UI parts.
+func HasA2UIParts(content string) bool {
+	return strings.Contains(content, schema.A2UIOpenTag) && strings.Contains(content, schema.A2UICloseTag)
+}
+
+// sanitizeJSONString removes markdown code blocks from the JSON string.
+func sanitizeJSONString(jsonString string) string {
+	jsonString = strings.TrimSpace(jsonString)
+	jsonString = strings.TrimPrefix(jsonString, "```json")
+	jsonString = strings.TrimPrefix(jsonString, "```")
+	jsonString = strings.TrimSuffix(jsonString, "```")
+	jsonString = strings.TrimSpace(jsonString)
+	return jsonString
+}
+
+// ParseResponse parses the LLM response into a list of ResponsePart objects.
+//
+// It extracts A2UI JSON blocks delimited by <a2ui-json> and </a2ui-json> tags,
+// sanitizes the JSON, and returns both text and structured parts.
+func ParseResponse(content string) ([]ResponsePart, error) {
+	matches := a2uiBlockPattern.FindAllStringSubmatchIndex(content, -1)
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("A2UI tags '%s' and '%s' not found in response",
+			schema.A2UIOpenTag, schema.A2UICloseTag)
+	}
+
+	var responseParts []ResponsePart
+	lastEnd := 0
+
+	for _, match := range matches {
+		// match[0:2] is the full match, match[2:4] is group 1
+		start := match[0]
+		end := match[1]
+
+		// Text preceding the JSON block.
+		textPart := strings.TrimSpace(content[lastEnd:start])
+
+		// The JSON content within the tags.
+		jsonString := content[match[2]:match[3]]
+		jsonStringCleaned := sanitizeJSONString(jsonString)
+		if jsonStringCleaned == "" {
+			return nil, fmt.Errorf("A2UI JSON part is empty")
+		}
+
+		jsonData, err := ParseAndFix(jsonStringCleaned)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse A2UI JSON: %w", err)
+		}
+		responseParts = append(responseParts, ResponsePart{
+			Text:     textPart,
+			A2UIJSON: jsonData,
+		})
+		lastEnd = end
+	}
+
+	// Trailing text after the last JSON block.
+	trailingText := strings.TrimSpace(content[lastEnd:])
+	if trailingText != "" {
+		responseParts = append(responseParts, ResponsePart{
+			Text:     trailingText,
+			A2UIJSON: nil,
+		})
+	}
+
+	return responseParts, nil
+}

--- a/agent_sdks/go/parser/parser_test.go
+++ b/agent_sdks/go/parser/parser_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/AGenUI/AGenUI/agent_sdks/go/schema"
+)
+
+func TestParseEmptyResponse(t *testing.T) {
+	_, err := ParseResponse("")
+	if err == nil {
+		t.Error("expected error for empty response")
+	}
+	if !strings.Contains(err.Error(), "not found in response") {
+		t.Errorf("expected 'not found in response' error, got: %v", err)
+	}
+}
+
+func TestParseResponseOnlyTextNoTags(t *testing.T) {
+	_, err := ParseResponse("Only text, no tags.")
+	if err == nil {
+		t.Error("expected error for text-only response")
+	}
+	if !strings.Contains(err.Error(), "not found in response") {
+		t.Errorf("expected 'not found in response' error, got: %v", err)
+	}
+}
+
+func TestParseResponseEmptyTags(t *testing.T) {
+	content := schema.A2UIOpenTag + schema.A2UICloseTag
+	_, err := ParseResponse(content)
+	if err == nil {
+		t.Error("expected error for empty tags")
+	}
+	if !strings.Contains(err.Error(), "A2UI JSON part is empty") {
+		t.Errorf("expected 'A2UI JSON part is empty' error, got: %v", err)
+	}
+}
+
+func TestParseResponseOnlyJSONWithTags(t *testing.T) {
+	content := fmt.Sprintf("%s\n[{\"id\": \"test\"}]\n%s", schema.A2UIOpenTag, schema.A2UICloseTag)
+	parts, err := ParseResponse(content)
+	if err != nil {
+		t.Fatalf("ParseResponse failed: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parts))
+	}
+	if parts[0].Text != "" {
+		t.Errorf("expected empty text, got %q", parts[0].Text)
+	}
+	if len(parts[0].A2UIJSON) != 1 {
+		t.Fatalf("expected 1 JSON element, got %d", len(parts[0].A2UIJSON))
+	}
+	if parts[0].A2UIJSON[0]["id"] != "test" {
+		t.Errorf("expected id=test, got %v", parts[0].A2UIJSON[0]["id"])
+	}
+}
+
+func TestParseResponseWithTextAndTags(t *testing.T) {
+	content := fmt.Sprintf("Hello\n%s\n[{\"id\": \"test\"}]\n%s", schema.A2UIOpenTag, schema.A2UICloseTag)
+	parts, err := ParseResponse(content)
+	if err != nil {
+		t.Fatalf("ParseResponse failed: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parts))
+	}
+	if parts[0].Text != "Hello" {
+		t.Errorf("expected text=Hello, got %q", parts[0].Text)
+	}
+	if parts[0].A2UIJSON[0]["id"] != "test" {
+		t.Errorf("expected id=test, got %v", parts[0].A2UIJSON[0]["id"])
+	}
+}
+
+func TestParseResponseWithTrailingText(t *testing.T) {
+	content := fmt.Sprintf("Hello\n%s\n[{\"id\": \"test\"}]\n%s\nGoodbye",
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+	parts, err := ParseResponse(content)
+	if err != nil {
+		t.Fatalf("ParseResponse failed: %v", err)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	if parts[0].Text != "Hello" {
+		t.Errorf("expected text=Hello, got %q", parts[0].Text)
+	}
+	if parts[0].A2UIJSON[0]["id"] != "test" {
+		t.Errorf("expected id=test, got %v", parts[0].A2UIJSON[0]["id"])
+	}
+	if parts[1].Text != "Goodbye" {
+		t.Errorf("expected text=Goodbye, got %q", parts[1].Text)
+	}
+	if parts[1].A2UIJSON != nil {
+		t.Errorf("expected nil A2UIJSON for trailing text, got %v", parts[1].A2UIJSON)
+	}
+}
+
+func TestParseResponseMultipleBlocks(t *testing.T) {
+	content := fmt.Sprintf(`
+Part 1
+%s
+[{"id": "1"}]
+%s
+Part 2
+%s
+[{"id": "2"}]
+%s
+Part 3
+  `, schema.A2UIOpenTag, schema.A2UICloseTag, schema.A2UIOpenTag, schema.A2UICloseTag)
+	parts, err := ParseResponse(content)
+	if err != nil {
+		t.Fatalf("ParseResponse failed: %v", err)
+	}
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts, got %d", len(parts))
+	}
+
+	if parts[0].Text != "Part 1" {
+		t.Errorf("expected text='Part 1', got %q", parts[0].Text)
+	}
+	if parts[0].A2UIJSON[0]["id"] != "1" {
+		t.Errorf("expected id=1, got %v", parts[0].A2UIJSON[0]["id"])
+	}
+
+	if parts[1].Text != "Part 2" {
+		t.Errorf("expected text='Part 2', got %q", parts[1].Text)
+	}
+	if parts[1].A2UIJSON[0]["id"] != "2" {
+		t.Errorf("expected id=2, got %v", parts[1].A2UIJSON[0]["id"])
+	}
+
+	if parts[2].Text != "Part 3" {
+		t.Errorf("expected text='Part 3', got %q", parts[2].Text)
+	}
+	if parts[2].A2UIJSON != nil {
+		t.Errorf("expected nil A2UIJSON for trailing text, got %v", parts[2].A2UIJSON)
+	}
+}
+
+func TestParseResponseWithMarkdownBlocks(t *testing.T) {
+	content := fmt.Sprintf("Text\n%s\n```json\n[{\"id\": \"test\"}]\n```\n%s",
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+	parts, err := ParseResponse(content)
+	if err != nil {
+		t.Fatalf("ParseResponse failed: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parts))
+	}
+	if parts[0].Text != "Text" {
+		t.Errorf("expected text=Text, got %q", parts[0].Text)
+	}
+	if parts[0].A2UIJSON[0]["id"] != "test" {
+		t.Errorf("expected id=test, got %v", parts[0].A2UIJSON[0]["id"])
+	}
+}
+
+func TestParseResponseInvalidJSON(t *testing.T) {
+	content := fmt.Sprintf("%s\ninvalid_json\n%s", schema.A2UIOpenTag, schema.A2UICloseTag)
+	_, err := ParseResponse(content)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestHasA2UIParts(t *testing.T) {
+	tests := []struct {
+		content  string
+		expected bool
+	}{
+		{
+			content:  fmt.Sprintf("%s test %s", schema.A2UIOpenTag, schema.A2UICloseTag),
+			expected: true,
+		},
+		{
+			content:  "no tags here",
+			expected: false,
+		},
+		{
+			content:  schema.A2UIOpenTag + " only open tag",
+			expected: false,
+		},
+		{
+			content:  "only close tag " + schema.A2UICloseTag,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		got := HasA2UIParts(tt.content)
+		if got != tt.expected {
+			t.Errorf("HasA2UIParts(%q) = %v, want %v", tt.content, got, tt.expected)
+		}
+	}
+}
+
+func TestSanitizeJSONString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain", `[{"id": "test"}]`, `[{"id": "test"}]`},
+		{"with json fence", "```json\n[{\"id\": \"test\"}]\n```", `[{"id": "test"}]`},
+		{"with plain fence", "```\n[{\"id\": \"test\"}]\n```", `[{"id": "test"}]`},
+		{"with spaces", "  [  ]  ", "[  ]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeJSONString(tt.input)
+			if got != tt.expected {
+				t.Errorf("sanitizeJSONString(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/agent_sdks/go/parser/payload_fixer.go
+++ b/agent_sdks/go/parser/payload_fixer.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ParseAndFix validates and applies autofixes to a raw JSON string and returns the parsed payload.
+func ParseAndFix(payload string) ([]map[string]any, error) {
+	normalized := normalizeSmartQuotes(payload)
+
+	result, err := parseJSON(normalized)
+	if err != nil {
+		logger.Printf("initial A2UI payload validation failed: %v", err)
+		updated := removeTrailingCommas(normalized)
+		return parseJSON(updated)
+	}
+	return result, nil
+}
+
+// parseJSON parses the payload and returns a list of A2UI JSON objects.
+func parseJSON(payload string) ([]map[string]any, error) {
+	var raw any
+	if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	switch v := raw.(type) {
+	case []any:
+		result := make([]map[string]any, 0, len(v))
+		for _, item := range v {
+			if m, ok := item.(map[string]any); ok {
+				result = append(result, m)
+			}
+		}
+		return result, nil
+	case map[string]any:
+		logger.Printf("received a single JSON object, wrapping in a list for validation")
+		return []map[string]any{v}, nil
+	default:
+		return nil, fmt.Errorf("unexpected JSON type: %T", raw)
+	}
+}
+
+// normalizeSmartQuotes replaces smart (curly) quotes with standard straight quotes.
+func normalizeSmartQuotes(s string) string {
+	s = strings.ReplaceAll(s, "\u201C", "\"")
+	s = strings.ReplaceAll(s, "\u201D", "\"")
+	s = strings.ReplaceAll(s, "\u2018", "'")
+	s = strings.ReplaceAll(s, "\u2019", "'")
+	return s
+}
+
+var trailingCommaRe = regexp.MustCompile(`,\s*([\]}])`)
+
+// removeTrailingCommas attempts to remove trailing commas from a JSON string.
+func removeTrailingCommas(s string) string {
+	fixed := trailingCommaRe.ReplaceAllString(s, "$1")
+	if fixed != s {
+		logger.Printf("detected trailing commas in LLM output; applied autofix")
+	}
+	return fixed
+}

--- a/agent_sdks/go/parser/payload_fixer_test.go
+++ b/agent_sdks/go/parser/payload_fixer_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"testing"
+)
+
+func TestRemoveTrailingCommas(t *testing.T) {
+	// Malformed JSON with a trailing comma in the list
+	malformedList := `[{"type": "Text", "text": "Hello"},]`
+	fixedList := removeTrailingCommas(malformedList)
+	expected := `[{"type": "Text", "text": "Hello"}]`
+	if fixedList != expected {
+		t.Errorf("removeTrailingCommas list: got %q, want %q", fixedList, expected)
+	}
+
+	// Malformed JSON with a trailing comma in the object
+	malformedObj := `{"type": "Text", "text": "Hello",}`
+	fixedObj := removeTrailingCommas(malformedObj)
+	expectedObj := `{"type": "Text", "text": "Hello"}`
+	if fixedObj != expectedObj {
+		t.Errorf("removeTrailingCommas obj: got %q, want %q", fixedObj, expectedObj)
+	}
+}
+
+func TestRemoveTrailingCommasNoChange(t *testing.T) {
+	validJSON := `[{"type": "Text", "text": "Hello"}]`
+	fixed := removeTrailingCommas(validJSON)
+	if fixed != validJSON {
+		t.Errorf("removeTrailingCommas should not modify valid JSON: got %q, want %q", fixed, validJSON)
+	}
+}
+
+func TestParseJSONWrapping(t *testing.T) {
+	// _parse auto-wraps single objects in a list
+	objJSON := `{"type": "Text", "text": "Hello"}`
+	parsed, err := parseJSON(objJSON)
+	if err != nil {
+		t.Fatalf("parseJSON failed: %v", err)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(parsed))
+	}
+	if parsed[0]["type"] != "Text" {
+		t.Errorf("expected type=Text, got %v", parsed[0]["type"])
+	}
+}
+
+func TestParseAndFixSuccessFirstTime(t *testing.T) {
+	validJSON := `[{"type": "Text", "text": "Hello"}]`
+	result, err := ParseAndFix(validJSON)
+	if err != nil {
+		t.Fatalf("ParseAndFix failed: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(result))
+	}
+	if result[0]["type"] != "Text" {
+		t.Errorf("expected type=Text, got %v", result[0]["type"])
+	}
+	if result[0]["text"] != "Hello" {
+		t.Errorf("expected text=Hello, got %v", result[0]["text"])
+	}
+}
+
+func TestParseAndFixSuccessAfterFix(t *testing.T) {
+	malformedJSON := `[{"type": "Text", "text": "Hello"},]`
+	result, err := ParseAndFix(malformedJSON)
+	if err != nil {
+		t.Fatalf("ParseAndFix failed: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(result))
+	}
+	if result[0]["type"] != "Text" {
+		t.Errorf("expected type=Text, got %v", result[0]["type"])
+	}
+}
+
+func TestNormalizesSmartQuotes(t *testing.T) {
+	// Smart (curly) quotes should be replaced with standard quotes
+	smartQuotesJSON := "{\u201Ctype\u201D: \u201CText\u201D, \u201Cother\u201D: \u201CValue\u2019s\u201D}"
+	result, err := ParseAndFix(smartQuotesJSON)
+	if err != nil {
+		t.Fatalf("ParseAndFix failed: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(result))
+	}
+	if result[0]["type"] != "Text" {
+		t.Errorf("expected type=Text, got %v", result[0]["type"])
+	}
+	if result[0]["other"] != "Value's" {
+		t.Errorf("expected other=Value's, got %v", result[0]["other"])
+	}
+}
+
+func TestParseJSONInvalid(t *testing.T) {
+	_, err := parseJSON("not valid json")
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestParseJSONArray(t *testing.T) {
+	arrayJSON := `[{"a": 1}, {"b": 2}]`
+	result, err := parseJSON(arrayJSON)
+	if err != nil {
+		t.Fatalf("parseJSON failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(result))
+	}
+}
+
+func TestParseJSONUnexpectedType(t *testing.T) {
+	_, err := parseJSON(`"just a string"`)
+	if err == nil {
+		t.Error("expected error for unexpected JSON type, got nil")
+	}
+}

--- a/agent_sdks/go/parser/response_part.go
+++ b/agent_sdks/go/parser/response_part.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+// ResponsePart represents a part of the LLM response.
+type ResponsePart struct {
+	// Text is the conversational text part. Can be an empty string.
+	Text string
+	// A2UIJSON is the parsed A2UI JSON data. Always a list of maps if
+	// it contains A2UI messages. Nil if this part only contains trailing text.
+	A2UIJSON []map[string]any
+}

--- a/agent_sdks/go/parser/streaming.go
+++ b/agent_sdks/go/parser/streaming.go
@@ -1,0 +1,1056 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/AGenUI/AGenUI/agent_sdks/go/schema"
+)
+
+// CuttableKeys contains keys whose string values can be safely auto-closed (healed)
+// if fragmented in the stream. Structural or atomic keys (e.g., id, surfaceId, path)
+// are NOT cuttable to prevent incorrect parsing or data binding.
+var CuttableKeys = map[string]struct{}{
+	"literalString": {},
+	"valueString":   {},
+	"label":         {},
+	"hint":          {},
+	"caption":       {},
+	"altText":       {},
+	"text":          {},
+}
+
+// maxJSONBufferSize is the maximum allowed size of the JSON buffer (10 MB).
+// If the buffer exceeds this limit without a closing </a2ui-json> tag,
+// the parser resets to prevent unbounded memory growth from malformed LLM output.
+const maxJSONBufferSize = 10 * 1024 * 1024
+
+// braceEntry tracks the type and position of an opening brace/bracket.
+type braceEntry struct {
+	bType    string // "{" or "["
+	startIdx int
+}
+
+// streamParserImpl defines the interface that version-specific parsers must implement.
+type streamParserImpl interface {
+	// placeholderComponent returns the version-specific placeholder component.
+	placeholderComponent() map[string]any
+	// yieldedSurfacesSet returns a reference to the yielded surfaces tracking set.
+	yieldedSurfacesSet() map[string]struct{}
+	// addToYieldedSurfaces adds a surface to the yielded set.
+	addToYieldedSurfaces(sid string)
+	// removeFromYieldedSurfaces removes a surface from the yielded set.
+	removeFromYieldedSurfaces(sid string)
+	// isProtocolMsg checks if the object is a recognized A2UI message for this version.
+	isProtocolMsg(obj map[string]any) bool
+	// dataModelMsgType returns the message type identifier for data model updates.
+	dataModelMsgType() string
+	// getActiveMsgTypeForComponents determines which msg_type to use when wrapping component updates.
+	getActiveMsgTypeForComponents() string
+	// handleCompleteObject handles an object that has been fully parsed.
+	handleCompleteObject(obj map[string]any, sid string, messages *[]ResponsePart) (bool, error)
+	// constructPartialMessage constructs a partial message for streaming.
+	constructPartialMessage(components []map[string]any, activeMsgType string) map[string]any
+	// sniffMetadata sniffs for surfaceId, root, and msg_types in the json_buffer.
+	sniffMetadata()
+	// deduplicateDataModel returns true if message should be yielded.
+	deduplicateDataModel(m map[string]any, strictIntegrity bool) bool
+	// sniffPartialDataModel sniffs for partial data model updates.
+	sniffPartialDataModel(messages *[]ResponsePart)
+	// constructSniffedDataModelMessage constructs a sniffed data model message.
+	constructSniffedDataModelMessage(activeMsgType string, payload map[string]any) map[string]any
+}
+
+// A2uiStreamParser parses a stream of text for A2UI JSON messages with fine-grained
+// component yielding. Use NewA2uiStreamParser to create a version-specific parser.
+type A2uiStreamParser struct {
+	impl streamParserImpl
+
+	version      string
+	refFieldsMap schema.RefFieldsMap
+	validator    *schema.A2uiValidator
+
+	foundDelimiter bool
+	buffer         string
+	jsonBuffer     string
+	braceStack     []braceEntry
+	braceCount     int
+	inTopLevelList bool
+	inString       bool
+	stringEscaped  bool
+
+	seenComponents map[string]map[string]any
+
+	// Track data model for path resolution.
+	yieldedDataModel map[string]any
+	deletedSurfaces  map[string]struct{}
+
+	// surfaceId -> set of cids
+	yieldedIDs map[string]map[string]struct{}
+	// (surfaceId, cid) -> hash of content for change detection
+	yieldedContents map[[2]string]string
+
+	rootIDs       map[string]string // root component IDs per surface
+	defaultRootID string            // base default root ID for the protocol
+	unboundRootID *string           // temporary holding when root arrives before surfaceId
+	surfaceID     *string           // active surface ID
+
+	msgTypes      []string // running list of message types seen in the block
+	activeMsgType string   // current active message type for component grouping
+
+	// A set of surface ids for which we have already yielded a start message.
+	yieldedStartMessages map[string]struct{}
+
+	// State for buffering updates until surface is ready.
+	pendingMessages     map[string][]map[string]any
+	bufferedStartMsg    map[string]any
+	topologyDirty       bool
+	foundValidJSONBlock bool
+}
+
+// NewA2uiStreamParser creates a streaming parser for A2UI v0.9.
+func NewA2uiStreamParser(catalog *schema.A2uiCatalog) *A2uiStreamParser {
+	version := ""
+	if catalog != nil {
+		version = catalog.Version
+	}
+
+	var refFieldsMap schema.RefFieldsMap
+	if catalog != nil {
+		refFieldsMap = schema.ExtractComponentRefFields(catalog)
+	} else {
+		refFieldsMap = make(schema.RefFieldsMap)
+	}
+
+	var validator *schema.A2uiValidator
+	if catalog != nil {
+		validator = schema.NewA2uiValidator(catalog)
+	}
+
+	p := &A2uiStreamParser{
+		version:              version,
+		refFieldsMap:         refFieldsMap,
+		validator:            validator,
+		seenComponents:       make(map[string]map[string]any),
+		yieldedDataModel:     make(map[string]any),
+		deletedSurfaces:      make(map[string]struct{}),
+		yieldedIDs:           make(map[string]map[string]struct{}),
+		yieldedContents:      make(map[[2]string]string),
+		rootIDs:              make(map[string]string),
+		yieldedStartMessages: make(map[string]struct{}),
+		pendingMessages:      make(map[string][]map[string]any),
+	}
+
+	p.impl = newStreamParserV09(p)
+	p.defaultRootID = DefaultRootID
+
+	return p
+}
+
+// SurfaceID returns the current surface ID.
+func (p *A2uiStreamParser) SurfaceID() string {
+	if p.surfaceID == nil {
+		return ""
+	}
+	return *p.surfaceID
+}
+
+// SetSurfaceID sets the current surface ID.
+func (p *A2uiStreamParser) SetSurfaceID(value string) {
+	p.surfaceID = &value
+	if p.unboundRootID != nil {
+		p.rootIDs[value] = *p.unboundRootID
+		p.unboundRootID = nil
+	}
+}
+
+// RootID returns the current root component ID.
+func (p *A2uiStreamParser) RootID() string {
+	if p.surfaceID != nil {
+		if rid, ok := p.rootIDs[*p.surfaceID]; ok {
+			return rid
+		}
+		return p.defaultRootID
+	}
+	if p.unboundRootID != nil {
+		return *p.unboundRootID
+	}
+	return p.defaultRootID
+}
+
+// SetRootID sets the root component ID.
+func (p *A2uiStreamParser) SetRootID(value string) {
+	if p.surfaceID != nil {
+		p.rootIDs[*p.surfaceID] = value
+	} else {
+		p.unboundRootID = &value
+	}
+}
+
+// MsgTypes returns the list of message types seen.
+func (p *A2uiStreamParser) MsgTypes() []string {
+	return p.msgTypes
+}
+
+// AddMsgType adds a message type if not already present.
+func (p *A2uiStreamParser) AddMsgType(msgType string) {
+	found := false
+	for _, mt := range p.msgTypes {
+		if mt == msgType {
+			found = true
+			break
+		}
+	}
+	if !found {
+		p.msgTypes = append(p.msgTypes, msgType)
+	}
+	if msgType == MsgTypeUpdateComponents || msgType == MsgTypeCreateSurface {
+		p.activeMsgType = msgType
+	}
+}
+
+// ProcessChunk processes a chunk of text and returns any complete A2UI messages found.
+// This is the primary entry point for the streaming parser.
+func (p *A2uiStreamParser) ProcessChunk(chunk string) ([]ResponsePart, error) {
+	var messages []ResponsePart
+	p.buffer += chunk
+
+	for {
+		if !p.foundDelimiter {
+			// Looking for <a2ui-json>
+			if idx := strings.Index(p.buffer, schema.A2UIOpenTag); idx >= 0 {
+				if idx > 0 {
+					messages = append(messages, ResponsePart{Text: p.buffer[:idx]})
+				}
+				p.foundDelimiter = true
+				p.buffer = p.buffer[idx+len(schema.A2UIOpenTag):]
+				continue
+			}
+			// Yield conversational text while avoiding split tags.
+			keepLen := 0
+			for i := len(schema.A2UIOpenTag) - 1; i > 0; i-- {
+				if strings.HasSuffix(p.buffer, schema.A2UIOpenTag[:i]) {
+					keepLen = i
+					break
+				}
+			}
+			if len(p.buffer) > keepLen {
+				safeToYield := len(p.buffer) - keepLen
+				messages = append(messages, ResponsePart{Text: p.buffer[:safeToYield]})
+				p.buffer = p.buffer[safeToYield:]
+			}
+			break
+		}
+
+		// Looking for </a2ui-json>
+		if idx := strings.Index(p.buffer, schema.A2UICloseTag); idx >= 0 {
+			jsonFragment := p.buffer[:idx]
+			if err := p.processJSONChunk(jsonFragment, &messages); err != nil {
+				return messages, err
+			}
+			if !p.foundValidJSONBlock {
+				return messages, fmt.Errorf("failed to parse JSON: No valid JSON object found in A2UI block")
+			}
+			p.foundDelimiter = false
+			p.resetJSONState()
+			p.buffer = p.buffer[idx+len(schema.A2UICloseTag):]
+			continue
+		}
+		// Avoid split close tag.
+		keepLen := 0
+		for i := 1; i < len(schema.A2UICloseTag); i++ {
+			if strings.HasSuffix(p.buffer, schema.A2UICloseTag[:i]) {
+				keepLen = i
+			}
+		}
+		if keepLen < len(p.buffer) {
+			toProcess := p.buffer[:len(p.buffer)-keepLen]
+			p.buffer = p.buffer[len(p.buffer)-keepLen:]
+			if err := p.processJSONChunk(toProcess, &messages); err != nil {
+				return messages, err
+			}
+		}
+		break
+	}
+
+	// Deduplicate updateComponents messages.
+	for i := range messages {
+		part := &messages[i]
+		if len(part.A2UIJSON) == 0 {
+			continue
+		}
+		var deduped []map[string]any
+		seenUC := make(map[string]struct{})
+		for j := len(part.A2UIJSON) - 1; j >= 0; j-- {
+			m := part.A2UIJSON[j]
+			isUC := false
+			sid := ""
+			if uc, ok := m[MsgTypeUpdateComponents].(map[string]any); ok {
+				isUC = true
+				sid, _ = uc[schema.SurfaceIDKey].(string)
+			}
+			if isUC && sid != "" {
+				if _, seen := seenUC[sid]; !seen {
+					deduped = append(deduped, m)
+					seenUC[sid] = struct{}{}
+				}
+			} else {
+				deduped = append(deduped, m)
+			}
+		}
+		// Reverse deduped.
+		for left, right := 0, len(deduped)-1; left < right; left, right = left+1, right-1 {
+			deduped[left], deduped[right] = deduped[right], deduped[left]
+		}
+		part.A2UIJSON = deduped
+	}
+
+	return messages, nil
+}
+
+func (p *A2uiStreamParser) resetJSONState() {
+	p.jsonBuffer = ""
+	p.braceStack = nil
+	p.braceCount = 0
+	p.inTopLevelList = false
+	p.inString = false
+	p.stringEscaped = false
+	p.msgTypes = nil
+	p.foundValidJSONBlock = false
+}
+
+// fixJSON attempts to fix a partial JSON fragment by adding missing closing delimiters.
+func (p *A2uiStreamParser) fixJSON(fragment string) string {
+	fixed := strings.TrimRight(fragment, " \t\n\r")
+	if fixed == "" {
+		return ""
+	}
+
+	stack := []string{}
+	inStr := false
+	escaped := false
+	lastQuoteIdx := -1
+
+	for i, ch := range fixed {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == '"' {
+			inStr = !inStr
+			if inStr {
+				lastQuoteIdx = i
+			}
+		} else if !inStr {
+			if ch == '{' || ch == '[' {
+				stack = append(stack, string(ch))
+			} else if ch == '}' || ch == ']' {
+				if len(stack) > 0 {
+					stack = stack[:len(stack)-1]
+				}
+			}
+		}
+	}
+
+	// Close open strings (healing).
+	if inStr {
+		prefix := strings.TrimRight(fixed[:lastQuoteIdx], " \t\n\r")
+		if strings.HasSuffix(prefix, ":") {
+			keyMatchRe := regexp.MustCompile(`"([^"]+)"\s*:\s*$`)
+			keyMatches := keyMatchRe.FindStringSubmatch(prefix)
+			if len(keyMatches) > 1 {
+				key := keyMatches[1]
+				if _, ok := CuttableKeys[key]; !ok {
+					return ""
+				}
+				// Don't cut URL bindings.
+				if key == "valueString" {
+					stringVal := fixed[lastQuoteIdx+1:]
+					if strings.HasPrefix(stringVal, "http://") || strings.HasPrefix(stringVal, "https://") ||
+						strings.HasPrefix(stringVal, "data:") || strings.HasPrefix(stringVal, "/") {
+						return ""
+					}
+					prevKeyRe := regexp.MustCompile(`"key"\s*:\s*"([^"]+)"`)
+					lookback := prefix
+					if len(lookback) > 200 {
+						lookback = lookback[len(lookback)-200:]
+					}
+					prevKeyMatches := prevKeyRe.FindAllStringSubmatch(lookback, -1)
+					if len(prevKeyMatches) > 0 {
+						dataKey := strings.ToLower(prevKeyMatches[len(prevKeyMatches)-1][1])
+						for _, urlKey := range []string{"url", "link", "src", "href", "image"} {
+							if strings.Contains(dataKey, urlKey) {
+								return ""
+							}
+						}
+					}
+				}
+			}
+		}
+		fixed += `"`
+	}
+
+	// Clean up trailing comma.
+	fixed = strings.TrimRight(fixed, " \t\n\r")
+	if strings.HasSuffix(fixed, ",") {
+		fixed = strings.TrimRight(fixed[:len(fixed)-1], " \t\n\r")
+	}
+
+	// Close braces and brackets.
+	for i := len(stack) - 1; i >= 0; i-- {
+		if stack[i] == "{" {
+			fixed += "}"
+		} else {
+			fixed += "]"
+		}
+	}
+
+	return fixed
+}
+
+// processJSONChunk processes a chunk of JSON characters.
+func (p *A2uiStreamParser) processJSONChunk(chunk string, messages *[]ResponsePart) error {
+	for _, char := range chunk {
+		// Guard against unbounded buffer growth from malformed LLM output
+		// that never produces a closing </a2ui-json> tag.
+		if len(p.jsonBuffer) > maxJSONBufferSize {
+			logger.Printf("JSON buffer exceeded %d bytes, resetting parser state", maxJSONBufferSize)
+			p.resetJSONState()
+			return nil
+		}
+
+		charHandled := false
+		ch := string(char)
+
+		if !p.inTopLevelList {
+			if char == '[' {
+				if p.braceCount == 0 {
+					p.inTopLevelList = true
+				}
+				p.braceStack = append(p.braceStack, braceEntry{"[", len(p.jsonBuffer)})
+				p.jsonBuffer += "["
+				p.braceCount++
+				charHandled = true
+			} else {
+				continue
+			}
+		}
+
+		// Track string state.
+		if !charHandled && p.inString {
+			if p.stringEscaped {
+				p.stringEscaped = false
+				if p.braceCount > 0 {
+					p.jsonBuffer += ch
+				}
+			} else if char == '\\' {
+				p.stringEscaped = true
+				if p.braceCount > 0 {
+					p.jsonBuffer += ch
+				}
+			} else if char == '"' {
+				p.inString = false
+				if p.braceCount > 0 {
+					p.jsonBuffer += ch
+				}
+			} else {
+				if p.braceCount > 0 {
+					p.jsonBuffer += ch
+				}
+			}
+			charHandled = true
+		}
+
+		if !charHandled {
+			switch char {
+			case '"':
+				p.inString = true
+				p.stringEscaped = false
+				if p.braceCount > 0 {
+					p.jsonBuffer += ch
+				}
+			case '{':
+				if p.braceCount == 0 {
+					p.msgTypes = nil
+				}
+				p.braceStack = append(p.braceStack, braceEntry{"{", len(p.jsonBuffer)})
+				p.jsonBuffer += "{"
+				p.braceCount++
+			case '}':
+				if len(p.braceStack) > 0 {
+					entry := p.braceStack[len(p.braceStack)-1]
+					p.braceStack = p.braceStack[:len(p.braceStack)-1]
+					p.jsonBuffer += "}"
+					p.braceCount--
+
+					if p.braceCount >= 0 {
+						startIdx := entry.startIdx
+						objBuffer := p.jsonBuffer[startIdx:]
+						if strings.HasPrefix(objBuffer, "{") && strings.HasSuffix(objBuffer, "}") {
+							var obj map[string]any
+							dec := json.NewDecoder(strings.NewReader(objBuffer))
+							dec.UseNumber()
+							if err := dec.Decode(&obj); err == nil {
+								p.foundValidJSONBlock = true
+
+								isProtocol := p.inTopLevelList && p.impl.isProtocolMsg(obj)
+								_, hasID := obj["id"]
+								_, hasComp := obj["component"]
+								isComp := hasID && hasComp
+
+								isTopLevel := (len(p.braceStack) == 0) ||
+									(p.inTopLevelList && len(p.braceStack) == 1 && p.braceStack[0].bType == "[")
+
+								if isComp {
+									p.handlePartialComponent(obj, messages)
+								} else if isTopLevel || isProtocol {
+									handled, hErr := p.impl.handleCompleteObject(obj, p.SurfaceID(), messages)
+									if hErr != nil {
+										return hErr
+									}
+									if !handled {
+										if err := p.yieldMessages([]map[string]any{obj}, messages, true); err != nil {
+											return err
+										}
+									}
+								}
+
+								if p.braceCount == 0 || (p.inTopLevelList && len(p.braceStack) == 1) {
+									p.jsonBuffer = p.jsonBuffer[:startIdx] + p.jsonBuffer[startIdx+len(objBuffer):]
+									if len(p.braceStack) > 0 {
+										shift := len(objBuffer)
+										for i := range p.braceStack {
+											if p.braceStack[i].startIdx > startIdx {
+												p.braceStack[i].startIdx -= shift
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			case '[':
+				p.braceStack = append(p.braceStack, braceEntry{"[", len(p.jsonBuffer)})
+				p.jsonBuffer += "["
+				p.braceCount++
+			case ']':
+				if len(p.braceStack) > 0 && p.braceStack[len(p.braceStack)-1].bType == "[" {
+					p.braceStack = p.braceStack[:len(p.braceStack)-1]
+					p.jsonBuffer += "]"
+					p.braceCount--
+					if p.braceCount == 0 {
+						p.inTopLevelList = false
+					}
+				}
+			default:
+				if p.braceCount > 0 {
+					p.jsonBuffer += ch
+				}
+			}
+		}
+
+		// Sniff metadata.
+		if p.braceCount > 0 && (char == '"' || char == ':' || char == ',' || char == '}' || char == ']') {
+			p.impl.sniffMetadata()
+		}
+	}
+
+	// Sniff for partial components.
+	if p.braceCount >= 1 && p.jsonBuffer != "" {
+		p.sniffPartialComponent(messages)
+		p.impl.sniffPartialDataModel(messages)
+	}
+
+	if p.topologyDirty {
+		if err := p.yieldReachable(messages, false, false); err != nil {
+			return err
+		}
+		p.topologyDirty = false
+	}
+
+	return nil
+}
+
+// yieldMessages validates and appends messages to the final output list.
+func (p *A2uiStreamParser) yieldMessages(messagesToYield []map[string]any, messages *[]ResponsePart, strictIntegrity bool) error {
+	for _, m := range messagesToYield {
+		if !p.impl.deduplicateDataModel(m, strictIntegrity) {
+			continue
+		}
+
+		if p.validator != nil {
+			if err := p.validator.Validate(m, p.RootID(), strictIntegrity); err != nil {
+				if strictIntegrity {
+					return fmt.Errorf("validation failed: %w", err)
+				}
+				logger.Printf("Validation failed for partial/sniffed message: %v", err)
+				continue
+			}
+		}
+
+		if len(*messages) > 0 && (*messages)[len(*messages)-1].A2UIJSON == nil {
+			(*messages)[len(*messages)-1].A2UIJSON = []map[string]any{m}
+		} else if len(*messages) > 0 && len((*messages)[len(*messages)-1].A2UIJSON) > 0 {
+			(*messages)[len(*messages)-1].A2UIJSON = append((*messages)[len(*messages)-1].A2UIJSON, m)
+		} else {
+			*messages = append(*messages, ResponsePart{A2UIJSON: []map[string]any{m}})
+		}
+	}
+	return nil
+}
+
+// deleteSurface clears all state related to a specific surface.
+func (p *A2uiStreamParser) deleteSurface(sid string) {
+	delete(p.pendingMessages, sid)
+	delete(p.yieldedIDs, sid)
+
+	newContents := make(map[[2]string]string)
+	for k, v := range p.yieldedContents {
+		if k[0] != sid {
+			newContents[k] = v
+		}
+	}
+	p.yieldedContents = newContents
+
+	p.impl.removeFromYieldedSurfaces(sid)
+	delete(p.yieldedStartMessages, sid)
+	p.deletedSurfaces[sid] = struct{}{}
+}
+
+// handlePartialComponent handles a component discovered before its parent message is finished.
+func (p *A2uiStreamParser) handlePartialComponent(comp map[string]any, messages *[]ResponsePart) {
+	compID, _ := comp["id"].(string)
+	if compID == "" {
+		return
+	}
+
+	// Skip caching if component has empty dictionaries.
+	if hasEmptyDict(comp) {
+		return
+	}
+
+	p.seenComponents[compID] = comp
+	p.topologyDirty = true
+}
+
+func hasEmptyDict(obj any) bool {
+	switch v := obj.(type) {
+	case map[string]any:
+		if len(v) == 0 {
+			return true
+		}
+		for _, val := range v {
+			if hasEmptyDict(val) {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if hasEmptyDict(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// sniffPartialComponent attempts to parse a partial component from the current buffer.
+func (p *A2uiStreamParser) sniffPartialComponent(messages *[]ResponsePart) {
+	if !strings.Contains(p.jsonBuffer, `"`+schema.CatalogComponentsKey+`"`) {
+		return
+	}
+	for i := len(p.braceStack) - 1; i >= 0; i-- {
+		entry := p.braceStack[i]
+		if entry.bType != "{" {
+			continue
+		}
+		rawFragment := p.jsonBuffer[entry.startIdx:]
+		if rawFragment == "" {
+			continue
+		}
+		fixedFragment := p.fixJSON(rawFragment)
+		var obj map[string]any
+		dec := json.NewDecoder(strings.NewReader(fixedFragment))
+		dec.UseNumber()
+		if err := dec.Decode(&obj); err != nil {
+			continue
+		}
+		idVal, hasID := obj["id"]
+		compVal, hasComp := obj["component"]
+		if !hasID || !hasComp || idVal == nil {
+			continue
+		}
+		switch cv := compVal.(type) {
+		case string:
+			p.handlePartialComponent(obj, messages)
+		case map[string]any:
+			if len(cv) > 0 {
+				p.handlePartialComponent(obj, messages)
+			}
+		}
+	}
+}
+
+// yieldReachable yields a partial message containing all reachable and seen components.
+func (p *A2uiStreamParser) yieldReachable(messages *[]ResponsePart, checkRoot, raiseOnOrphans bool) error {
+	activeMsgType := p.impl.getActiveMsgTypeForComponents()
+	if p.RootID() == "" || activeMsgType == "" {
+		return nil
+	}
+	if p.surfaceID == nil {
+		return nil
+	}
+	sid := *p.surfaceID
+	yieldedSurfaces := p.impl.yieldedSurfacesSet()
+	if _, ok := yieldedSurfaces[sid]; !ok {
+		if p.bufferedStartMsg == nil {
+			return nil
+		}
+	}
+
+	componentsToAnalyze := make([]map[string]any, 0, len(p.seenComponents))
+	for _, comp := range p.seenComponents {
+		componentsToAnalyze = append(componentsToAnalyze, comp)
+	}
+
+	rootID := p.RootID()
+	if checkRoot {
+		if _, ok := p.seenComponents[rootID]; !ok {
+			logger.Printf("No root component (id='%s') found in %s", rootID, activeMsgType)
+			return nil
+		}
+	}
+
+	reachableIDs, err := schema.AnalyzeTopology(rootID, componentsToAnalyze, p.refFieldsMap, raiseOnOrphans)
+	if err != nil {
+		errLower := strings.ToLower(err.Error())
+		if strings.Contains(errLower, "circular reference detected") || strings.Contains(errLower, "self-reference detected") {
+			return err
+		}
+		if raiseOnOrphans || strings.Contains(errLower, "circular") || strings.Contains(errLower, "self-reference") ||
+			strings.Contains(errLower, "recursion") {
+			logger.Printf("yield_reachable error (strict=%v): %v", checkRoot, err)
+			return nil
+		}
+		return nil
+	}
+
+	// Filter to available reachable IDs.
+	availableReachable := make(map[string]struct{})
+	for id := range reachableIDs {
+		if _, ok := p.seenComponents[id]; ok {
+			availableReachable[id] = struct{}{}
+		}
+	}
+
+	if checkRoot && len(availableReachable) == 0 {
+		logger.Printf("No root component (id='%s') found in %s", rootID, activeMsgType)
+		return nil
+	}
+
+	// Process placeholders and partial children.
+	var processedComponents []map[string]any
+	var extraComponents []map[string]any
+	surfaceID := p.SurfaceID()
+	if surfaceID == "" {
+		surfaceID = "unknown"
+	}
+	yieldedForSurface := p.yieldedIDs[surfaceID]
+
+	sortedIDs := make([]string, 0, len(availableReachable))
+	for id := range availableReachable {
+		sortedIDs = append(sortedIDs, id)
+	}
+	sort.Strings(sortedIDs)
+
+	for _, rid := range sortedIDs {
+		comp := deepCopyAny(p.seenComponents[rid]).(map[string]any)
+		_, reYielding := yieldedForSurface[rid]
+		p.processComponentTopology(comp, &extraComponents, reYielding)
+		processedComponents = append(processedComponents, comp)
+	}
+	processedComponents = append(processedComponents, extraComponents...)
+
+	// Check if we have NEW or UPDATED reachable components.
+	if surfaceID == "" || p.isDeletedSurface(surfaceID) {
+		return nil
+	}
+
+	shouldYield := false
+	for id := range availableReachable {
+		if _, ok := yieldedForSurface[id]; !ok {
+			shouldYield = true
+			break
+		}
+	}
+	if !shouldYield {
+		for _, comp := range processedComponents {
+			cid, _ := comp["id"].(string)
+			contentStr := jsonMarshalSorted(comp)
+			stateKey := [2]string{surfaceID, cid}
+			if p.yieldedContents[stateKey] != contentStr {
+				shouldYield = true
+				break
+			}
+		}
+	}
+
+	if shouldYield {
+		currentSID := surfaceID
+		if _, ok := p.yieldedStartMessages[currentSID]; !ok {
+			if p.bufferedStartMsg != nil {
+				if err := p.yieldMessages([]map[string]any{p.bufferedStartMsg}, messages, true); err != nil {
+					return err
+				}
+				p.yieldedStartMessages[currentSID] = struct{}{}
+				p.impl.addToYieldedSurfaces(currentSID)
+			}
+		}
+
+		partialMsg := p.impl.constructPartialMessage(processedComponents, activeMsgType)
+		p.yieldMessages([]map[string]any{partialMsg}, messages, false)
+
+		if p.yieldedIDs[surfaceID] == nil {
+			p.yieldedIDs[surfaceID] = make(map[string]struct{})
+		}
+		for id := range availableReachable {
+			p.yieldedIDs[surfaceID][id] = struct{}{}
+		}
+
+		for _, comp := range processedComponents {
+			cid, _ := comp["id"].(string)
+			p.yieldedContents[[2]string{surfaceID, cid}] = jsonMarshalSorted(comp)
+		}
+	}
+	return nil
+}
+
+func (p *A2uiStreamParser) isDeletedSurface(sid string) bool {
+	_, ok := p.deletedSurfaces[sid]
+	return ok
+}
+
+// getPlaceholderID returns the ID to use for a missing child placeholder.
+func (p *A2uiStreamParser) getPlaceholderID(childID string) string {
+	return "loading_" + childID
+}
+
+// processComponentTopology recursively processes path placeholders and child pruning.
+func (p *A2uiStreamParser) processComponentTopology(comp map[string]any, extraComponents *[]map[string]any, inlineResolved bool) {
+	compID, _ := comp["id"].(string)
+	if compID == "" {
+		compID = "unknown"
+	}
+
+	var traverse func(obj any, parentKey string)
+	traverse = func(obj any, parentKey string) {
+		switch v := obj.(type) {
+		case map[string]any:
+			// Handle path placeholders.
+			if pathVal, ok := v["path"].(string); ok && strings.HasPrefix(pathVal, "/") {
+				key := strings.TrimPrefix(pathVal, "/")
+				if p.version != schema.Version09 {
+					if _, hasCompID := v["componentId"]; !hasCompID {
+						for k := range v {
+							delete(v, k)
+						}
+					}
+					v["path"] = "/" + key
+				}
+			} else if p.version != schema.Version09 {
+				if currentPath, ok := v["path"]; ok {
+					pathStr := fmt.Sprintf("%v", currentPath)
+					if !strings.HasPrefix(pathStr, "/") {
+						v["path"] = "/" + pathStr
+					}
+				}
+			}
+
+			// Handle child pruning.
+			childFields := []string{"children", "explicitList", "child", "contentChild", "entryPointChild", "componentId"}
+			for _, field := range childFields {
+				val, ok := v[field]
+				if !ok {
+					continue
+				}
+				switch fieldVal := val.(type) {
+				case []any:
+					var validChildren []any
+					for _, childItem := range fieldVal {
+						childIDStr, ok := childItem.(string)
+						if !ok {
+							validChildren = append(validChildren, childItem)
+							continue
+						}
+						if _, ok := p.seenComponents[childIDStr]; ok {
+							validChildren = append(validChildren, childIDStr)
+						} else {
+							placeholderID := p.getPlaceholderID(childIDStr)
+							validChildren = append(validChildren, placeholderID)
+							placeholderComp := map[string]any{"id": placeholderID}
+							for k, pv := range p.impl.placeholderComponent() {
+								placeholderComp[k] = pv
+							}
+							if !containsID(*extraComponents, placeholderID) {
+								*extraComponents = append(*extraComponents, placeholderComp)
+							}
+						}
+					}
+					if len(validChildren) == 0 && (field == "children" || field == "explicitList") {
+						// Heuristic: check if the list field is still "open" (unclosed bracket)
+						// in the JSON buffer, indicating more children are expected from the stream.
+						// NOTE: this searches the full buffer, which in rare cases could match a
+						// same-named field from a different component. This matches the Python SDK behavior.
+						term := `"` + field + `"`
+						if strings.Contains(p.jsonBuffer, term) {
+							afterField := p.jsonBuffer[strings.LastIndex(p.jsonBuffer, term)+len(term):]
+							if strings.Contains(afterField, "[") && !strings.Contains(strings.SplitN(afterField, "[", 2)[0], "]") {
+								placeholderID := fmt.Sprintf("loading_children_%s", compID)
+								validChildren = append(validChildren, placeholderID)
+								placeholderComp := map[string]any{"id": placeholderID}
+								for k, pv := range p.impl.placeholderComponent() {
+									placeholderComp[k] = pv
+								}
+								if !containsID(*extraComponents, placeholderID) {
+									*extraComponents = append(*extraComponents, placeholderComp)
+								}
+							}
+						}
+					}
+					v[field] = validChildren
+				case string:
+					if _, ok := p.seenComponents[fieldVal]; !ok {
+						placeholderID := p.getPlaceholderID(fieldVal)
+						v[field] = placeholderID
+						placeholderComp := map[string]any{"id": placeholderID}
+						for k, pv := range p.impl.placeholderComponent() {
+							placeholderComp[k] = pv
+						}
+						if !containsID(*extraComponents, placeholderID) {
+							*extraComponents = append(*extraComponents, placeholderComp)
+						}
+					}
+				}
+			}
+
+			// Continue traversal.
+			for k, val := range v {
+				traverse(val, k)
+			}
+		case []any:
+			for _, item := range v {
+				traverse(item, parentKey)
+			}
+		}
+	}
+
+	if compMap, ok := comp["component"].(map[string]any); ok {
+		traverse(compMap, "")
+	} else {
+		traverse(comp, "")
+	}
+}
+
+// parseContentsToDict recursively parses A2UI contents into a flat dictionary.
+func (p *A2uiStreamParser) parseContentsToDict(rawContents any) map[string]any {
+	switch v := rawContents.(type) {
+	case map[string]any:
+		return v
+	case []any:
+		res := make(map[string]any)
+		for _, entry := range v {
+			e, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			key, _ := e["key"].(string)
+			var val any
+			for _, vkey := range []string{"value", "valueString", "valueNumber", "valueBoolean"} {
+				if vv, ok := e[vkey]; ok {
+					val = vv
+					break
+				}
+			}
+			if val == nil {
+				if vm, ok := e["valueMap"]; ok {
+					val = p.parseContentsToDict(vm)
+				}
+			}
+			if key != "" && val != nil {
+				res[key] = val
+			}
+		}
+		return res
+	}
+	return nil
+}
+
+// UpdateDataModel updates the internal data model and marks affected components as dirty.
+func (p *A2uiStreamParser) UpdateDataModel(update map[string]any, messages *[]ResponsePart) {
+	rawContents := update["contents"]
+	if rawContents != nil {
+		_ = p.parseContentsToDict(rawContents)
+	}
+}
+
+// Helper functions.
+
+func containsID(components []map[string]any, id string) bool {
+	for _, c := range components {
+		if cid, _ := c["id"].(string); cid == id {
+			return true
+		}
+	}
+	return false
+}
+
+func deepCopyAny(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		m := make(map[string]any, len(val))
+		for k, v := range val {
+			m[k] = deepCopyAny(v)
+		}
+		return m
+	case []any:
+		s := make([]any, len(val))
+		for i, v := range val {
+			s[i] = deepCopyAny(v)
+		}
+		return s
+	default:
+		return v
+	}
+}
+
+func jsonMarshalSorted(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		logger.Printf("jsonMarshalSorted failed: %v", err)
+		return ""
+	}
+	return string(b)
+}

--- a/agent_sdks/go/parser/streaming_test.go
+++ b/agent_sdks/go/parser/streaming_test.go
@@ -1,0 +1,593 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/AGenUI/AGenUI/agent_sdks/go/schema"
+)
+
+// newTestCatalog creates a minimal catalog for testing purposes.
+func newTestCatalog(t *testing.T) *schema.A2uiCatalog {
+	t.Helper()
+	return &schema.A2uiCatalog{
+		Version: schema.Version09,
+		Name:    "test",
+		S2CSchema: map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"oneOf": []any{
+				map[string]any{"$ref": "#/$defs/CreateSurfaceMessage"},
+				map[string]any{"$ref": "#/$defs/UpdateComponentsMessage"},
+			},
+			"$defs": map[string]any{
+				"CreateSurfaceMessage": map[string]any{
+					"type":                 "object",
+					"additionalProperties": true,
+				},
+				"UpdateComponentsMessage": map[string]any{
+					"type":                 "object",
+					"additionalProperties": true,
+				},
+			},
+		},
+		CommonTypesSchema: map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"$defs":   map[string]any{},
+		},
+		CatalogSchema: map[string]any{
+			"catalogId": "test_catalog",
+			"components": map[string]any{
+				"Text": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"literalString": map[string]any{"type": "string"}},
+				},
+				"Row": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"children": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					},
+				},
+				"Column": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"children": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					},
+				},
+				"Button": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"label": map[string]any{"type": "string"}},
+				},
+			},
+		},
+	}
+}
+
+// feedChunked feeds content to the parser character by character.
+func feedChunked(p *A2uiStreamParser, content string) ([]ResponsePart, error) {
+	var allParts []ResponsePart
+	for _, ch := range content {
+		parts, err := p.ProcessChunk(string(ch))
+		if err != nil {
+			return allParts, err
+		}
+		allParts = append(allParts, parts...)
+	}
+	return allParts, nil
+}
+
+// feedAsOneChunk feeds all content as a single chunk.
+func feedAsOneChunk(p *A2uiStreamParser, content string) ([]ResponsePart, error) {
+	return p.ProcessChunk(content)
+}
+
+// collectA2UIMessages extracts all A2UI JSON messages from response parts.
+func collectA2UIMessages(parts []ResponsePart) []map[string]any {
+	var msgs []map[string]any
+	for _, p := range parts {
+		msgs = append(msgs, p.A2UIJSON...)
+	}
+	return msgs
+}
+
+// collectText extracts all text from response parts.
+func collectText(parts []ResponsePart) string {
+	var texts []string
+	for _, p := range parts {
+		if p.Text != "" {
+			texts = append(texts, p.Text)
+		}
+	}
+	return strings.Join(texts, "")
+}
+
+func TestStreamParser_ConversationalTextOnly(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+	parts, err := p.ProcessChunk("Hello, this is just text!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := collectText(parts)
+	if !strings.Contains(text, "Hello") {
+		t.Errorf("expected text to contain 'Hello', got %q", text)
+	}
+	msgs := collectA2UIMessages(parts)
+	if len(msgs) > 0 {
+		t.Errorf("expected no A2UI messages for plain text, got %d", len(msgs))
+	}
+}
+
+func TestStreamParser_SimpleCreateSurface(t *testing.T) {
+	catalog := newTestCatalog(t)
+	p := NewA2uiStreamParser(catalog)
+
+	content := fmt.Sprintf(`Here is some UI:
+%s
+[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text", "literalString": "Hello"}]}}]
+%s
+Done!`, schema.A2UIOpenTag, schema.A2UICloseTag)
+
+	parts, err := feedAsOneChunk(p, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := collectText(parts)
+	if !strings.Contains(text, "Here is some UI:") {
+		t.Errorf("expected leading text, got %q", text)
+	}
+}
+
+func TestStreamParser_ChunkedInput(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	content := fmt.Sprintf(`Text before %s[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text", "literalString": "Hello"}]}}]%s Text after`, schema.A2UIOpenTag, schema.A2UICloseTag)
+
+	parts, err := feedChunked(p, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := collectText(parts)
+	if !strings.Contains(text, "Text before") {
+		t.Errorf("expected leading text 'Text before', got %q", text)
+	}
+	if !strings.Contains(text, "Text after") {
+		t.Errorf("expected trailing text 'Text after', got %q", text)
+	}
+}
+
+func TestStreamParser_MultipleBlocks(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	block1 := `[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text", "literalString": "First"}]}}]`
+	block2 := `[{"updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "literalString": "Updated"}]}}]`
+	content := fmt.Sprintf(`%s%s%s Middle text %s%s%s`, schema.A2UIOpenTag, block1, schema.A2UICloseTag, schema.A2UIOpenTag, block2, schema.A2UICloseTag)
+
+	parts, err := feedAsOneChunk(p, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := collectText(parts)
+	if !strings.Contains(text, "Middle text") {
+		t.Errorf("expected middle text between blocks, got %q", text)
+	}
+}
+
+func TestStreamParser_EmptyBlock(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	content := fmt.Sprintf(`%s%s`, schema.A2UIOpenTag, schema.A2UICloseTag)
+	_, err := feedAsOneChunk(p, content)
+	if err == nil {
+		t.Error("expected error for empty A2UI block")
+	}
+	if !strings.Contains(err.Error(), "No valid JSON object found") {
+		t.Errorf("expected 'No valid JSON object found' error, got: %v", err)
+	}
+}
+
+func TestStreamParser_SplitOpenTag(t *testing.T) {
+	// Test that the parser handles the open tag being split across chunks.
+	p := NewA2uiStreamParser(nil)
+
+	json := `[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text"}]}}]`
+
+	// Split the open tag across chunks.
+	tag := schema.A2UIOpenTag
+	mid := len(tag) / 2
+	chunk1 := "Hello " + tag[:mid]
+	chunk2 := tag[mid:] + json + schema.A2UICloseTag
+
+	parts1, err := p.ProcessChunk(chunk1)
+	if err != nil {
+		t.Fatalf("unexpected error on chunk1: %v", err)
+	}
+	parts2, err := p.ProcessChunk(chunk2)
+	if err != nil {
+		t.Fatalf("unexpected error on chunk2: %v", err)
+	}
+
+	allParts := append(parts1, parts2...)
+	text := collectText(allParts)
+	if !strings.Contains(text, "Hello") {
+		t.Errorf("expected text 'Hello', got %q", text)
+	}
+}
+
+func TestStreamParser_SplitCloseTag(t *testing.T) {
+	// Test that the parser handles the close tag being split across chunks.
+	p := NewA2uiStreamParser(nil)
+
+	json := `[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text"}]}}]`
+
+	tag := schema.A2UICloseTag
+	mid := len(tag) / 2
+	chunk1 := schema.A2UIOpenTag + json + tag[:mid]
+	chunk2 := tag[mid:] + " Done"
+
+	parts1, err := p.ProcessChunk(chunk1)
+	if err != nil {
+		t.Fatalf("unexpected error on chunk1: %v", err)
+	}
+	parts2, err := p.ProcessChunk(chunk2)
+	if err != nil {
+		t.Fatalf("unexpected error on chunk2: %v", err)
+	}
+
+	allParts := append(parts1, parts2...)
+	text := collectText(allParts)
+	if !strings.Contains(text, "Done") {
+		t.Errorf("expected trailing text 'Done', got %q", text)
+	}
+}
+
+func TestStreamParser_UpdateComponents(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	content := fmt.Sprintf(`%s[{"updateComponents": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Row", "children": ["c1"]}, {"id": "c1", "component": "Text", "literalString": "Child"}]}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+
+	_, err := feedAsOneChunk(p, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStreamParser_UpdateDataModel(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	content := fmt.Sprintf(`%s[{"updateDataModel": {"surfaceId": "s1", "value": {"name": "test", "count": 42}}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+
+	parts, err := feedAsOneChunk(p, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	msgs := collectA2UIMessages(parts)
+	found := false
+	for _, m := range msgs {
+		if _, ok := m[MsgTypeUpdateDataModel]; ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected an updateDataModel message")
+	}
+}
+
+func TestStreamParser_DeleteSurface(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	// First create a surface, then delete it.
+	createContent := fmt.Sprintf(`%s[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text"}]}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+	_, err := feedAsOneChunk(p, createContent)
+	if err != nil {
+		t.Fatalf("unexpected error creating surface: %v", err)
+	}
+
+	deleteContent := fmt.Sprintf(`%s[{"deleteSurface": {"surfaceId": "s1"}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+	parts, err := feedAsOneChunk(p, deleteContent)
+	if err != nil {
+		t.Fatalf("unexpected error deleting surface: %v", err)
+	}
+
+	msgs := collectA2UIMessages(parts)
+	found := false
+	for _, m := range msgs {
+		if _, ok := m[MsgTypeDeleteSurface]; ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a deleteSurface message")
+	}
+}
+
+func TestStreamParser_FixJSON_ClosesOpenBraces(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	tests := []struct {
+		name     string
+		fragment string
+		valid    bool
+	}{
+		{"complete", `{"id": "test"}`, true},
+		{"unclosed_brace", `{"id": "test"`, true},
+		{"unclosed_bracket", `[{"id": "test"}`, true},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.fixJSON(tt.fragment)
+			if tt.valid {
+				if result == "" {
+					t.Error("expected non-empty result from fixJSON")
+					return
+				}
+				var parsed any
+				if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+					t.Errorf("fixJSON result is not valid JSON: %v, result=%q", err, result)
+				}
+			}
+		})
+	}
+}
+
+func TestStreamParser_FixJSON_ClosesOpenStrings(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	// A fragment with an unclosed cuttable string value.
+	fragment := `{"literalString": "Hello wor`
+	result := p.fixJSON(fragment)
+	if result == "" {
+		t.Fatal("expected non-empty result from fixJSON for cuttable key")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("fixJSON result is not valid JSON: %v", err)
+	}
+	val, ok := parsed["literalString"].(string)
+	if !ok {
+		t.Fatal("expected literalString to be a string")
+	}
+	if !strings.HasPrefix(val, "Hello wor") {
+		t.Errorf("expected value starting with 'Hello wor', got %q", val)
+	}
+}
+
+func TestStreamParser_FixJSON_NonCuttableKey(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	// A fragment with an unclosed non-cuttable string value.
+	fragment := `{"id": "some_incomp`
+	result := p.fixJSON(fragment)
+	// Non-cuttable keys should return empty string (cannot safely close).
+	if result != "" {
+		t.Errorf("expected empty result for non-cuttable key, got %q", result)
+	}
+}
+
+func TestStreamParser_FixJSON_TrailingComma(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	fragment := `{"id": "test", "component": "Text",`
+	result := p.fixJSON(fragment)
+	if result == "" {
+		t.Fatal("expected non-empty result from fixJSON")
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Errorf("fixJSON result is not valid JSON: %v, result=%q", err, result)
+	}
+}
+
+func TestStreamParser_V09_CreateSurfaceWithComponents(t *testing.T) {
+	catalog := newTestCatalog(t)
+	p := NewA2uiStreamParser(catalog)
+
+	content := fmt.Sprintf(`%s[{"createSurface": {"surfaceId": "main", "root": "root", "components": [{"id": "root", "component": "Column", "children": ["t1"]}, {"id": "t1", "component": "Text", "literalString": "Welcome"}]}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+
+	parts, err := feedAsOneChunk(p, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	msgs := collectA2UIMessages(parts)
+	foundCreate := false
+	for _, m := range msgs {
+		if _, ok := m[MsgTypeCreateSurface]; ok {
+			foundCreate = true
+			break
+		}
+	}
+	if !foundCreate {
+		t.Error("expected a createSurface message")
+	}
+
+	if p.SurfaceID() != "main" {
+		t.Errorf("expected surfaceID=main, got %q", p.SurfaceID())
+	}
+	if p.RootID() != "root" {
+		t.Errorf("expected rootID=root, got %q", p.RootID())
+	}
+}
+
+func TestStreamParser_V09_SurfaceIDSniffing(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	// Feed createSurface chunk-by-chunk to test sniffing.
+	content := fmt.Sprintf(`%s[{"createSurface": {"surfaceId": "sniffed_id", "root": "r1", "components": [{"id": "r1", "component": "Text"}]}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+
+	_, err := feedChunked(p, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if p.SurfaceID() != "sniffed_id" {
+		t.Errorf("expected surfaceID=sniffed_id, got %q", p.SurfaceID())
+	}
+	if p.RootID() != "r1" {
+		t.Errorf("expected rootID=r1, got %q", p.RootID())
+	}
+}
+
+func TestStreamParser_V09_DataModelDeduplication(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	// Create a surface first.
+	createContent := fmt.Sprintf(`%s[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text"}]}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+	_, err := feedAsOneChunk(p, createContent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// First data model update.
+	dm1 := fmt.Sprintf(`%s[{"updateDataModel": {"surfaceId": "s1", "value": {"name": "Alice"}}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+	parts1, err := feedAsOneChunk(p, dm1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msgs1 := collectA2UIMessages(parts1)
+	if len(msgs1) == 0 {
+		t.Error("expected at least one message from first data model update")
+	}
+
+	// Identical data model update should be deduplicated.
+	dm2 := fmt.Sprintf(`%s[{"updateDataModel": {"surfaceId": "s1", "value": {"name": "Alice"}}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+	parts2, err := feedAsOneChunk(p, dm2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The identical update should be deduplicated (no new messages).
+	msgs2 := collectA2UIMessages(parts2)
+	dmCount := 0
+	for _, m := range msgs2 {
+		if _, ok := m[MsgTypeUpdateDataModel]; ok {
+			dmCount++
+		}
+	}
+	if dmCount > 0 {
+		t.Errorf("expected deduplicated data model (0 new messages), got %d", dmCount)
+	}
+}
+
+func TestStreamParser_V09_MsgTypeTracking(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	// Feed the content character by character and check msg types mid-stream.
+	content := fmt.Sprintf(`%s[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text"}]}}]`,
+		schema.A2UIOpenTag)
+
+	// Feed just the open tag and JSON (without close tag) to observe internal state.
+	for _, ch := range content {
+		_, _ = p.ProcessChunk(string(ch))
+	}
+
+	// Mid-block, msg types should be tracked.
+	msgTypes := p.MsgTypes()
+	hasCreate := false
+	for _, mt := range msgTypes {
+		if mt == MsgTypeCreateSurface {
+			hasCreate = true
+		}
+	}
+	if !hasCreate {
+		t.Error("expected createSurface in msg types during block processing")
+	}
+
+	// After close tag, msg types reset.
+	_, err := p.ProcessChunk(schema.A2UICloseTag)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(p.MsgTypes()) != 0 {
+		t.Errorf("expected msg types to be reset after block, got %v", p.MsgTypes())
+	}
+}
+
+func TestStreamParser_ResetBetweenBlocks(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	// First block
+	block1 := fmt.Sprintf(`%s[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text"}]}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+	_, err := feedAsOneChunk(p, block1)
+	if err != nil {
+		t.Fatalf("unexpected error on block1: %v", err)
+	}
+
+	// Second block should work independently.
+	block2 := fmt.Sprintf(`%s[{"updateDataModel": {"surfaceId": "s1", "value": {"x": 1}}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+	_, err = feedAsOneChunk(p, block2)
+	if err != nil {
+		t.Fatalf("unexpected error on block2: %v", err)
+	}
+}
+
+func TestStreamParser_NoNilPanic(t *testing.T) {
+	// Parser created with nil catalog should not panic.
+	p := NewA2uiStreamParser(nil)
+
+	content := fmt.Sprintf(`%s[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Text"}]}}]%s`,
+		schema.A2UIOpenTag, schema.A2UICloseTag)
+
+	// Should not panic.
+	_, err := feedAsOneChunk(p, content)
+	if err != nil {
+		t.Fatalf("unexpected error with nil catalog: %v", err)
+	}
+}
+
+func TestStreamParser_LargePayload(t *testing.T) {
+	p := NewA2uiStreamParser(nil)
+
+	// Build a large component tree.
+	var components []string
+	rootChildren := []string{}
+	for i := 0; i < 20; i++ {
+		cid := fmt.Sprintf("c%d", i)
+		rootChildren = append(rootChildren, fmt.Sprintf("%q", cid))
+		components = append(components, fmt.Sprintf(`{"id": %q, "component": "Text", "literalString": "Item %d"}`, cid, i))
+	}
+	childrenStr := strings.Join(rootChildren, ", ")
+	componentsStr := strings.Join(components, ", ")
+	json := fmt.Sprintf(`[{"createSurface": {"surfaceId": "s1", "root": "root", "components": [{"id": "root", "component": "Column", "children": [%s]}, %s]}}]`,
+		childrenStr, componentsStr)
+
+	content := fmt.Sprintf(`%s%s%s`, schema.A2UIOpenTag, json, schema.A2UICloseTag)
+	_, err := feedAsOneChunk(p, content)
+	if err != nil {
+		t.Fatalf("unexpected error with large payload: %v", err)
+	}
+}

--- a/agent_sdks/go/parser/streaming_v09.go
+++ b/agent_sdks/go/parser/streaming_v09.go
@@ -1,0 +1,373 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/AGenUI/AGenUI/agent_sdks/go/schema"
+)
+
+// streamParserV09 is the streaming parser implementation for A2UI v0.9 specification.
+type streamParserV09 struct {
+	p                     *A2uiStreamParser
+	yieldedCreateSurfaces map[string]struct{}
+}
+
+func newStreamParserV09(p *A2uiStreamParser) *streamParserV09 {
+	return &streamParserV09{
+		p:                     p,
+		yieldedCreateSurfaces: make(map[string]struct{}),
+	}
+}
+
+func (v *streamParserV09) placeholderComponent() map[string]any {
+	return map[string]any{
+		"component": "Row",
+		"children":  []any{},
+	}
+}
+
+func (v *streamParserV09) yieldedSurfacesSet() map[string]struct{} {
+	return v.yieldedCreateSurfaces
+}
+
+func (v *streamParserV09) addToYieldedSurfaces(sid string) {
+	v.yieldedCreateSurfaces[sid] = struct{}{}
+}
+
+func (v *streamParserV09) removeFromYieldedSurfaces(sid string) {
+	delete(v.yieldedCreateSurfaces, sid)
+}
+
+func (v *streamParserV09) isProtocolMsg(obj map[string]any) bool {
+	for _, k := range []string{MsgTypeCreateSurface, MsgTypeUpdateComponents, MsgTypeUpdateDataModel} {
+		if _, ok := obj[k]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *streamParserV09) dataModelMsgType() string {
+	return MsgTypeUpdateDataModel
+}
+
+func (v *streamParserV09) sniffMetadata() {
+	getLatestValue := func(key string) *string {
+		idx := len(v.p.jsonBuffer)
+		for {
+			needle := `"` + key + `"`
+			pos := strings.LastIndex(v.p.jsonBuffer[:idx], needle)
+			if pos == -1 {
+				return nil
+			}
+			re := regexp.MustCompile(`"` + regexp.QuoteMeta(key) + `"\s*:\s*"([^"]+)"`)
+			match := re.FindStringSubmatch(v.p.jsonBuffer[pos:])
+			if match != nil {
+				return &match[1]
+			}
+			idx = pos
+			if idx <= 0 {
+				return nil
+			}
+		}
+	}
+
+	if sid := getLatestValue("surfaceId"); sid != nil {
+		v.p.SetSurfaceID(*sid)
+	}
+	if rootVal := getLatestValue("root"); rootVal != nil {
+		v.p.SetRootID(*rootVal)
+	}
+
+	if strings.Contains(v.p.jsonBuffer, `"`+MsgTypeCreateSurface+`":`) {
+		v.p.AddMsgType(MsgTypeCreateSurface)
+	}
+	if strings.Contains(v.p.jsonBuffer, `"`+MsgTypeUpdateComponents+`":`) {
+		v.p.AddMsgType(MsgTypeUpdateComponents)
+	}
+	if strings.Contains(v.p.jsonBuffer, `"`+MsgTypeUpdateDataModel+`":`) {
+		v.p.AddMsgType(MsgTypeUpdateDataModel)
+	}
+}
+
+func (v *streamParserV09) handleCompleteObject(obj map[string]any, sid string, messages *[]ResponsePart) (bool, error) {
+	if obj == nil {
+		return false, nil
+	}
+
+	if v.p.validator != nil {
+		if err := v.p.validator.Validate(obj, sid, false); err != nil {
+			return true, err
+		}
+	}
+
+	surfaceID := v.p.SurfaceID()
+	if uc, ok := obj[MsgTypeUpdateComponents].(map[string]any); ok {
+		if s, ok := uc[schema.SurfaceIDKey].(string); ok && s != "" {
+			surfaceID = s
+		}
+	} else if cs, ok := obj[MsgTypeCreateSurface].(map[string]any); ok {
+		if s, ok := cs[schema.SurfaceIDKey].(string); ok && s != "" {
+			surfaceID = s
+		}
+	}
+
+	if surfaceID != "" {
+		v.p.SetSurfaceID(surfaceID)
+	}
+	sidStr := v.p.SurfaceID()
+	if sidStr == "" {
+		sidStr = "unknown"
+	}
+
+	// v0.9: createSurface
+	if csVal, ok := obj[MsgTypeCreateSurface]; ok {
+		if cs, ok := csVal.(map[string]any); ok {
+			rootID := DefaultRootID
+			if r, ok := cs["root"].(string); ok {
+				rootID = r
+			} else if v.p.RootID() != "" {
+				rootID = v.p.RootID()
+			}
+			v.p.SetRootID(rootID)
+		}
+		v.p.bufferedStartMsg = obj
+
+		if _, yielded := v.p.yieldedStartMessages[sidStr]; !yielded {
+			if err := v.p.yieldMessages([]map[string]any{obj}, messages, true); err != nil {
+				return true, err
+			}
+			v.p.yieldedStartMessages[sidStr] = struct{}{}
+			v.yieldedCreateSurfaces[sidStr] = struct{}{}
+			v.p.bufferedStartMsg = nil
+		}
+
+		delete(v.p.pendingMessages, sidStr)
+
+		if err := v.p.yieldReachable(messages, false, false); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
+	// v0.9: updateComponents
+	if ucVal, ok := obj[MsgTypeUpdateComponents]; ok {
+		v.p.AddMsgType(MsgTypeUpdateComponents)
+		if uc, ok := ucVal.(map[string]any); ok {
+			rootID := DefaultRootID
+			if r, ok := uc["root"].(string); ok {
+				rootID = r
+			} else if v.p.RootID() != "" {
+				rootID = v.p.RootID()
+			}
+			v.p.SetRootID(rootID)
+
+			if comps, ok := uc["components"].([]any); ok {
+				for _, comp := range comps {
+					if c, ok := comp.(map[string]any); ok {
+						if id, ok := c["id"].(string); ok {
+							v.p.seenComponents[id] = c
+						}
+					}
+				}
+			}
+		}
+		if err := v.p.yieldReachable(messages, true, false); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
+	// v0.9: deleteSurface
+	if _, ok := obj[MsgTypeDeleteSurface]; ok {
+		if _, yielded := v.p.yieldedStartMessages[sidStr]; !yielded {
+			v.p.pendingMessages[sidStr] = append(v.p.pendingMessages[sidStr], obj)
+			return true, nil
+		}
+		v.p.AddMsgType(MsgTypeDeleteSurface)
+		if err := v.p.yieldMessages([]map[string]any{obj}, messages, true); err != nil {
+			return true, err
+		}
+		v.p.deleteSurface(sidStr)
+		return true, nil
+	}
+
+	// v0.9: updateDataModel
+	if udmVal, ok := obj[MsgTypeUpdateDataModel]; ok {
+		v.p.AddMsgType(MsgTypeUpdateDataModel)
+		if udm, ok := udmVal.(map[string]any); ok {
+			v.p.UpdateDataModel(udm, messages)
+		}
+		if err := v.p.yieldMessages([]map[string]any{obj}, messages, true); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (v *streamParserV09) constructPartialMessage(components []map[string]any, activeMsgType string) map[string]any {
+	payload := map[string]any{
+		schema.CatalogComponentsKey: components,
+	}
+	if sid := v.p.SurfaceID(); sid != "" {
+		payload[schema.SurfaceIDKey] = sid
+	}
+	return map[string]any{
+		"version":               "v0.9",
+		MsgTypeUpdateComponents: payload,
+	}
+}
+
+func (v *streamParserV09) getActiveMsgTypeForComponents() string {
+	if v.p.activeMsgType != "" {
+		return v.p.activeMsgType
+	}
+	for _, mt := range v.p.msgTypes {
+		if mt == MsgTypeUpdateComponents || mt == MsgTypeCreateSurface {
+			v.p.activeMsgType = mt
+			return mt
+		}
+	}
+	if len(v.p.msgTypes) > 0 {
+		return v.p.msgTypes[0]
+	}
+	return ""
+}
+
+func (v *streamParserV09) deduplicateDataModel(m map[string]any, strictIntegrity bool) bool {
+	udmVal, ok := m[MsgTypeUpdateDataModel]
+	if !ok {
+		return true
+	}
+	udm, ok := udmVal.(map[string]any)
+	if !ok {
+		return true
+	}
+	isNew := false
+	for k, val := range udm {
+		if k == schema.SurfaceIDKey || k == "root" {
+			continue
+		}
+		if !reflect.DeepEqual(v.p.yieldedDataModel[k], val) {
+			isNew = true
+			break
+		}
+	}
+	if !isNew && strictIntegrity {
+		return false
+	}
+	for k, val := range udm {
+		if k != schema.SurfaceIDKey && k != "root" {
+			v.p.yieldedDataModel[k] = val
+		}
+	}
+	return true
+}
+
+func (v *streamParserV09) sniffPartialDataModel(messages *[]ResponsePart) {
+	// v0.9 has a specialized sniff for "value" property.
+	msgType := MsgTypeUpdateDataModel
+	if !strings.Contains(v.p.jsonBuffer, `"`+msgType+`"`) {
+		return
+	}
+
+	for i := len(v.p.braceStack) - 1; i >= 0; i-- {
+		entry := v.p.braceStack[i]
+		if entry.bType != "{" {
+			continue
+		}
+		rawFragment := v.p.jsonBuffer[entry.startIdx:]
+		if rawFragment == "" {
+			continue
+		}
+
+		fixedFragment := v.p.fixJSON(rawFragment)
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(fixedFragment), &obj); err != nil {
+			trimmed := rawFragment
+			for strings.Contains(trimmed, ",") {
+				idx := strings.LastIndex(trimmed, ",")
+				trimmed = trimmed[:idx]
+				fixedTrimmed := v.p.fixJSON(trimmed)
+				if fixedTrimmed != "" {
+					if err := json.Unmarshal([]byte(fixedTrimmed), &obj); err == nil {
+						break
+					}
+				}
+			}
+		}
+
+		if obj == nil {
+			continue
+		}
+		dmValRaw, ok := obj[msgType]
+		if !ok {
+			continue
+		}
+		dmObj, ok := dmValRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		valueMap, ok := dmObj["value"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		delta := make(map[string]any)
+		for k, val := range valueMap {
+			if !reflect.DeepEqual(v.p.yieldedDataModel[k], val) {
+				delta[k] = val
+			}
+		}
+		if len(delta) == 0 {
+			continue
+		}
+
+		sid := ""
+		if s, ok := dmObj[schema.SurfaceIDKey].(string); ok {
+			sid = s
+		} else if v.p.surfaceID != nil {
+			sid = *v.p.surfaceID
+		} else {
+			sid = "default"
+		}
+
+		deltaMsgPayload := map[string]any{
+			schema.SurfaceIDKey: sid,
+			"value":             delta,
+		}
+		deltaMsg := v.constructSniffedDataModelMessage(msgType, deltaMsgPayload)
+		v.p.yieldMessages([]map[string]any{deltaMsg}, messages, false)
+		for k, val := range delta {
+			v.p.yieldedDataModel[k] = val
+		}
+	}
+}
+
+func (v *streamParserV09) constructSniffedDataModelMessage(activeMsgType string, payload map[string]any) map[string]any {
+	return map[string]any{
+		"version":     "v0.9",
+		activeMsgType: payload,
+	}
+}

--- a/agent_sdks/go/schema/assets.go
+++ b/agent_sdks/go/schema/assets.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import "embed"
+
+//go:embed assets/0.9/*.json
+var assetsFS embed.FS

--- a/agent_sdks/go/schema/assets/0.9/basic_catalog.json
+++ b/agent_sdks/go/schema/assets/0.9/basic_catalog.json
@@ -1,0 +1,1387 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://a2ui.org/specification/v0_9/basic_catalog.json",
+  "title": "A2UI Basic Catalog",
+  "description": "Unified catalog of basic A2UI components and functions.",
+  "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json",
+  "components": {
+    "Text": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Text"
+            },
+            "text": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text content to display. While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation."
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for the base text style.",
+              "enum": ["h1", "h2", "h3", "h4", "h5", "caption", "body"],
+              "default": "body"
+            }
+          },
+          "required": ["component", "text", "variant"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Image": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Image"
+            },
+            "url": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The URL of the image to display."
+            },
+            "description": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "Accessibility text for the image."
+            },
+            "fit": {
+              "type": "string",
+              "description": "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property.",
+              "enum": ["contain", "cover", "fill", "none", "scaleDown"],
+              "default": "fill"
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for the image size and style.",
+              "enum": [
+                "icon",
+                "avatar",
+                "smallFeature",
+                "mediumFeature",
+                "largeFeature",
+                "header"
+              ],
+              "default": "mediumFeature"
+            }
+          },
+          "required": ["component", "url"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Icon": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Icon"
+            },
+            "name": {
+              "description": "The name of the icon to display.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "accountCircle",
+                    "add",
+                    "arrowBack",
+                    "arrowForward",
+                    "attachFile",
+                    "calendarToday",
+                    "call",
+                    "camera",
+                    "check",
+                    "close",
+                    "delete",
+                    "download",
+                    "edit",
+                    "event",
+                    "error",
+                    "fastForward",
+                    "favorite",
+                    "favoriteOff",
+                    "folder",
+                    "help",
+                    "home",
+                    "info",
+                    "locationOn",
+                    "lock",
+                    "lockOpen",
+                    "mail",
+                    "menu",
+                    "moreVert",
+                    "moreHoriz",
+                    "notificationsOff",
+                    "notifications",
+                    "pause",
+                    "payment",
+                    "person",
+                    "phone",
+                    "photo",
+                    "play",
+                    "print",
+                    "refresh",
+                    "rewind",
+                    "search",
+                    "send",
+                    "settings",
+                    "share",
+                    "shoppingCart",
+                    "skipNext",
+                    "skipPrevious",
+                    "star",
+                    "starHalf",
+                    "starOff",
+                    "stop",
+                    "upload",
+                    "visibility",
+                    "visibilityOff",
+                    "volumeDown",
+                    "volumeMute",
+                    "volumeOff",
+                    "volumeUp",
+                    "warning"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["path"],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": ["component", "name"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Video": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Video"
+            },
+            "url": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The URL of the video to display."
+            }
+          },
+          "required": ["component", "url"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "AudioPlayer": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "AudioPlayer"
+            },
+            "url": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The URL of the audio to be played."
+            },
+            "description": {
+              "description": "A description of the audio, such as a title or summary.",
+              "$ref": "common_types.json#/$defs/DynamicString"
+            }
+          },
+          "required": ["component", "url"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Row": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "description": "A layout component that arranges its children horizontally. To create a grid layout, nest Columns within this Row.",
+          "properties": {
+            "component": {
+              "const": "Row"
+            },
+            "children": {
+              "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+              "$ref": "common_types.json#/$defs/ChildList"
+            },
+            "justify": {
+              "type": "string",
+              "description": "Defines the arrangement of children along the main axis (horizontally). Use 'spaceBetween' to push items to the edges, or 'start'/'end'/'center' to pack them together.",
+              "enum": [
+                "center",
+                "end",
+                "spaceAround",
+                "spaceBetween",
+                "spaceEvenly",
+                "start",
+                "stretch"
+              ],
+              "default": "start"
+            },
+            "align": {
+              "type": "string",
+              "description": "Defines the alignment of children along the cross axis (vertically). This is similar to the CSS 'align-items' property, but uses camelCase values (e.g., 'start').",
+              "enum": ["start", "center", "end", "stretch"],
+              "default": "stretch"
+            }
+          },
+          "required": ["component", "children"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Column": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "description": "A layout component that arranges its children vertically. To create a grid layout, nest Rows within this Column.",
+          "properties": {
+            "component": {
+              "const": "Column"
+            },
+            "children": {
+              "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+              "$ref": "common_types.json#/$defs/ChildList"
+            },
+            "justify": {
+              "type": "string",
+              "description": "Defines the arrangement of children along the main axis (vertically). Use 'spaceBetween' to push items to the edges (e.g. header at top, footer at bottom), or 'start'/'end'/'center' to pack them together.",
+              "enum": [
+                "start",
+                "center",
+                "end",
+                "spaceBetween",
+                "spaceAround",
+                "spaceEvenly",
+                "stretch"
+              ],
+              "default": "start"
+            },
+            "align": {
+              "type": "string",
+              "description": "Defines the alignment of children along the cross axis (horizontally). This is similar to the CSS 'align-items' property.",
+              "enum": ["center", "end", "start", "stretch"],
+              "default": "stretch"
+            }
+          },
+          "required": ["component", "children"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "List": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "List"
+            },
+            "children": {
+              "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list.",
+              "$ref": "common_types.json#/$defs/ChildList"
+            },
+            "direction": {
+              "type": "string",
+              "description": "The direction in which the list items are laid out.",
+              "enum": ["vertical", "horizontal"],
+              "default": "vertical"
+            },
+            "align": {
+              "type": "string",
+              "description": "Defines the alignment of children along the cross axis.",
+              "enum": ["start", "center", "end", "stretch"],
+              "default": "stretch"
+            }
+          },
+          "required": ["component", "children"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Card": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Card"
+            },
+            "child": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the single child component to be rendered inside the card. To display multiple elements, you MUST wrap them in a layout component (like Column or Row) and pass that container's ID here. Do NOT pass multiple IDs or a non-existent ID. Do NOT define the child component inline."
+            }
+          },
+          "required": ["component", "child"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Tabs": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Tabs"
+            },
+            "tabs": {
+              "type": "array",
+              "description": "An array of objects, where each object defines a tab with a title and a child component.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "description": "The tab title.",
+                    "$ref": "common_types.json#/$defs/DynamicString"
+                  },
+                  "child": {
+                    "$ref": "common_types.json#/$defs/ComponentId",
+                    "description": "The ID of the child component. Do NOT define the component inline."
+                  }
+                },
+                "required": ["title", "child"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["component", "tabs"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Modal": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Modal"
+            },
+            "trigger": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the component that opens the modal when interacted with (e.g., a button). Do NOT define the component inline."
+            },
+            "content": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the component to be displayed inside the modal. Do NOT define the component inline."
+            }
+          },
+          "required": ["component", "trigger", "content"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Divider": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Divider"
+            },
+            "axis": {
+              "type": "string",
+              "description": "The orientation of the divider.",
+              "enum": ["horizontal", "vertical"],
+              "default": "horizontal"
+            }
+          },
+          "required": ["component"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Button": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Button"
+            },
+            "child": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the child component. Use a 'Text' component for a labeled button. Only use an 'Icon' if the requirements explicitly ask for an icon-only button. Do NOT define the child component inline."
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for the button style. If omitted, a default button style is used. 'primary' indicates this is the main call-to-action button. 'borderless' means the button has no visual border or background, making its child content appear like a clickable link.",
+              "enum": ["default", "primary", "borderless"],
+              "default": "default"
+            },
+            "action": {
+              "$ref": "common_types.json#/$defs/Action"
+            }
+          },
+          "required": ["component", "child", "action"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "TextField": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "TextField"
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text label for the input field."
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The value of the text field."
+            },
+            "variant": {
+              "type": "string",
+              "description": "The type of input field to display.",
+              "enum": ["longText", "number", "shortText", "obscured"],
+              "default": "shortText"
+            },
+            "validationRegexp": {
+              "type": "string",
+              "description": "A regular expression used for client-side validation of the input."
+            }
+          },
+          "required": ["component", "label"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "CheckBox": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "CheckBox"
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text to display next to the checkbox."
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "The current state of the checkbox (true for checked, false for unchecked)."
+            }
+          },
+          "required": ["component", "label", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "ChoicePicker": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "description": "A component that allows selecting one or more options from a list.",
+          "properties": {
+            "component": {
+              "const": "ChoicePicker"
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The label for the group of options."
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for how the choice picker should be displayed and behave.",
+              "enum": ["multipleSelection", "mutuallyExclusive"],
+              "default": "mutuallyExclusive"
+            },
+            "options": {
+              "type": "array",
+              "description": "The list of available options to choose from.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "description": "The text to display for this option.",
+                    "$ref": "common_types.json#/$defs/DynamicString"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The stable value associated with this option."
+                  }
+                },
+                "required": ["label", "value"],
+                "additionalProperties": false
+              }
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicStringList",
+              "description": "The list of currently selected values. This should be bound to a string array in the data model."
+            },
+            "displayStyle": {
+              "type": "string",
+              "description": "The display style of the component.",
+              "enum": ["checkbox", "chips"],
+              "default": "checkbox"
+            },
+            "filterable": {
+              "type": "boolean",
+              "description": "If true, displays a search input to filter the options.",
+              "default": false
+            }
+          },
+          "required": ["component", "options", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Slider": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Slider"
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The label for the slider."
+            },
+            "min": {
+              "type": "number",
+              "description": "The minimum value of the slider.",
+              "default": 0
+            },
+            "max": {
+              "type": "number",
+              "description": "The maximum value of the slider."
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The current value of the slider."
+            }
+          },
+          "required": ["component", "value", "max"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "DateTimeInput": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "DateTimeInput"
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The selected date and/or time value in ISO 8601 format. If not yet set, initialize with an empty string."
+            },
+            "enableDate": {
+              "type": "boolean",
+              "description": "If true, allows the user to select a date.",
+              "default": false
+            },
+            "enableTime": {
+              "type": "boolean",
+              "description": "If true, allows the user to select a time.",
+              "default": false
+            },
+            "min": {
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "oneOf": [
+                      {
+                        "format": "date"
+                      },
+                      {
+                        "format": "time"
+                      },
+                      {
+                        "format": "date-time"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "description": "The minimum allowed date/time in ISO 8601 format."
+            },
+            "max": {
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "oneOf": [
+                      {
+                        "format": "date"
+                      },
+                      {
+                        "format": "time"
+                      },
+                      {
+                        "format": "date-time"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "description": "The maximum allowed date/time in ISO 8601 format."
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text label for the input field."
+            }
+          },
+          "required": ["component", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
+    }
+  },
+  "functions": {
+    "required": {
+      "type": "object",
+      "description": "Checks that the value is not null, undefined, or empty.",
+      "properties": {
+        "call": {
+          "const": "required"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "description": "The value to check."
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "regex": {
+      "type": "object",
+      "description": "Checks that the value matches a regular expression string.",
+      "properties": {
+        "call": {
+          "const": "regex"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString"
+            },
+            "pattern": {
+              "type": "string",
+              "description": "The regex pattern to match against."
+            }
+          },
+          "required": ["value", "pattern"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "length": {
+      "type": "object",
+      "description": "Checks string length constraints.",
+      "properties": {
+        "call": {
+          "const": "length"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString"
+            },
+            "min": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The minimum allowed length."
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The maximum allowed length."
+            }
+          },
+          "required": ["value"],
+          "anyOf": [
+            {
+              "required": ["min"]
+            },
+            {
+              "required": ["max"]
+            }
+          ],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "numeric": {
+      "type": "object",
+      "description": "Checks numeric range constraints.",
+      "properties": {
+        "call": {
+          "const": "numeric"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber"
+            },
+            "min": {
+              "type": "number",
+              "description": "The minimum allowed value."
+            },
+            "max": {
+              "type": "number",
+              "description": "The maximum allowed value."
+            }
+          },
+          "required": ["value"],
+          "anyOf": [
+            {
+              "required": ["min"]
+            },
+            {
+              "required": ["max"]
+            }
+          ],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "email": {
+      "type": "object",
+      "description": "Checks that the value is a valid email address.",
+      "properties": {
+        "call": {
+          "const": "email"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString"
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "formatString": {
+      "type": "object",
+      "description": "Performs string interpolation of data model values and other functions in the catalog functions list and returns the resulting string. The value string can contain interpolated expressions in the `${expression}` format. Supported expression types include: JSON Pointer paths to the data model (e.g., `${/absolute/path}` or `${relative/path}`), and client-side function calls (e.g., `${now()}`). Function arguments must be named (e.g., `${formatDate(value:${/currentDate}, format:'MM-dd')}`). To include a literal `${` sequence, escape it as `\\${`.",
+      "properties": {
+        "call": {
+          "const": "formatString"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString"
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "formatNumber": {
+      "type": "object",
+      "description": "Formats a number with the specified grouping and decimal precision.",
+      "properties": {
+        "call": {
+          "const": "formatNumber"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The number to format."
+            },
+            "decimals": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "Optional. The number of decimal places to show. Defaults to 0 or 2 depending on locale."
+            },
+            "grouping": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "Optional. If true, uses locale-specific grouping separators (e.g. '1,000'). If false, returns raw digits (e.g. '1000'). Defaults to true."
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "formatCurrency": {
+      "type": "object",
+      "description": "Formats a number as a currency string.",
+      "properties": {
+        "call": {
+          "const": "formatCurrency"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The monetary amount."
+            },
+            "currency": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The ISO 4217 currency code (e.g., 'USD', 'EUR')."
+            },
+            "decimals": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "Optional. The number of decimal places to show. Defaults to 0 or 2 depending on locale."
+            },
+            "grouping": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "Optional. If true, uses locale-specific grouping separators (e.g. '1,000'). If false, returns raw digits (e.g. '1000'). Defaults to true."
+            }
+          },
+          "required": ["currency", "value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "formatDate": {
+      "type": "object",
+      "description": "Formats a timestamp into a string using a pattern.",
+      "properties": {
+        "call": {
+          "const": "formatDate"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicValue",
+              "description": "The date to format."
+            },
+            "format": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "A Unicode TR35 date pattern string.\n\nToken Reference:\n- Year: 'yy' (26), 'yyyy' (2026)\n- Month: 'M' (1), 'MM' (01), 'MMM' (Jan), 'MMMM' (January)\n- Day: 'd' (1), 'dd' (01), 'E' (Tue), 'EEEE' (Tuesday)\n- Hour (12h): 'h' (1-12), 'hh' (01-12) - requires 'a' for AM/PM\n- Hour (24h): 'H' (0-23), 'HH' (00-23) - Military Time\n- Minute: 'mm' (00-59)\n- Second: 'ss' (00-59)\n- Period: 'a' (AM/PM)\n\nExamples:\n- 'MMM dd, yyyy' -> 'Jan 16, 2026'\n- 'HH:mm' -> '14:30' (Military)\n- 'h:mm a' -> '2:30 PM'\n- 'EEEE, d MMMM' -> 'Friday, 16 January'"
+            }
+          },
+          "required": ["format", "value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "pluralize": {
+      "type": "object",
+      "description": "Returns a localized string based on the Common Locale Data Repository (CLDR) plural category of the count (zero, one, two, few, many, other). Requires an 'other' fallback. For English, just use 'one' and 'other'.",
+      "properties": {
+        "call": {
+          "const": "pluralize"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The numeric value used to determine the plural category."
+            },
+            "zero": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'zero' category (e.g., 0 items)."
+            },
+            "one": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'one' category (e.g., 1 item)."
+            },
+            "two": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'two' category (used in Arabic, Welsh, etc.)."
+            },
+            "few": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'few' category (e.g., small groups in Slavic languages)."
+            },
+            "many": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'many' category (e.g., large groups in various languages)."
+            },
+            "other": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The default/fallback string (used for general plural cases)."
+            }
+          },
+          "required": ["value", "other"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "openUrl": {
+      "type": "object",
+      "description": "Opens the specified URL in a browser or handler. This function has no return value.",
+      "properties": {
+        "call": {
+          "const": "openUrl"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URL to open."
+            }
+          },
+          "required": ["url"],
+          "additionalProperties": false
+        },
+        "returnType": {
+          "const": "void"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "and": {
+      "type": "object",
+      "description": "Performs a logical AND operation on a list of boolean values.",
+      "properties": {
+        "call": {
+          "const": "and"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "values": {
+              "type": "array",
+              "description": "The list of boolean values to evaluate.",
+              "items": {
+                "$ref": "common_types.json#/$defs/DynamicBoolean"
+              },
+              "minItems": 2
+            }
+          },
+          "required": ["values"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "or": {
+      "type": "object",
+      "description": "Performs a logical OR operation on a list of boolean values.",
+      "properties": {
+        "call": {
+          "const": "or"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "values": {
+              "type": "array",
+              "description": "The list of boolean values to evaluate.",
+              "items": {
+                "$ref": "common_types.json#/$defs/DynamicBoolean"
+              },
+              "minItems": 2
+            }
+          },
+          "required": ["values"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "not": {
+      "type": "object",
+      "description": "Performs a logical NOT operation on a boolean value.",
+      "properties": {
+        "call": {
+          "const": "not"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "The boolean value to negate."
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    }
+  },
+  "$defs": {
+    "CatalogComponentCommon": {
+      "type": "object",
+      "properties": {
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      }
+    },
+    "theme": {
+      "type": "object",
+      "properties": {
+        "primaryColor": {
+          "type": "string",
+          "description": "The primary brand color used for highlights (e.g., primary buttons, active borders). Renderers may generate variants of this color for different contexts. Format: Hexadecimal code (e.g., '#00BFFF').",
+          "pattern": "^#[0-9a-fA-F]{6}$"
+        },
+        "iconUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "A URL for an image that identifies the agent or tool associated with the surface."
+        },
+        "agentDisplayName": {
+          "type": "string",
+          "description": "Text to be displayed next to the surface to identify the agent or tool that created it."
+        }
+      },
+      "additionalProperties": true
+    },
+    "anyComponent": {
+      "oneOf": [
+        {
+          "$ref": "#/components/Text"
+        },
+        {
+          "$ref": "#/components/Image"
+        },
+        {
+          "$ref": "#/components/Icon"
+        },
+        {
+          "$ref": "#/components/Video"
+        },
+        {
+          "$ref": "#/components/AudioPlayer"
+        },
+        {
+          "$ref": "#/components/Row"
+        },
+        {
+          "$ref": "#/components/Column"
+        },
+        {
+          "$ref": "#/components/List"
+        },
+        {
+          "$ref": "#/components/Card"
+        },
+        {
+          "$ref": "#/components/Tabs"
+        },
+        {
+          "$ref": "#/components/Modal"
+        },
+        {
+          "$ref": "#/components/Divider"
+        },
+        {
+          "$ref": "#/components/Button"
+        },
+        {
+          "$ref": "#/components/TextField"
+        },
+        {
+          "$ref": "#/components/CheckBox"
+        },
+        {
+          "$ref": "#/components/ChoicePicker"
+        },
+        {
+          "$ref": "#/components/Slider"
+        },
+        {
+          "$ref": "#/components/DateTimeInput"
+        }
+      ],
+      "discriminator": {
+        "propertyName": "component"
+      }
+    },
+    "anyFunction": {
+      "oneOf": [
+        {
+          "$ref": "#/functions/required"
+        },
+        {
+          "$ref": "#/functions/regex"
+        },
+        {
+          "$ref": "#/functions/length"
+        },
+        {
+          "$ref": "#/functions/numeric"
+        },
+        {
+          "$ref": "#/functions/email"
+        },
+        {
+          "$ref": "#/functions/formatString"
+        },
+        {
+          "$ref": "#/functions/formatNumber"
+        },
+        {
+          "$ref": "#/functions/formatCurrency"
+        },
+        {
+          "$ref": "#/functions/formatDate"
+        },
+        {
+          "$ref": "#/functions/pluralize"
+        },
+        {
+          "$ref": "#/functions/openUrl"
+        },
+        {
+          "$ref": "#/functions/and"
+        },
+        {
+          "$ref": "#/functions/or"
+        },
+        {
+          "$ref": "#/functions/not"
+        }
+      ]
+    }
+  }
+}

--- a/agent_sdks/go/schema/assets/0.9/common_types.json
+++ b/agent_sdks/go/schema/assets/0.9/common_types.json
@@ -1,0 +1,315 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://a2ui.org/specification/v0_9/common_types.json",
+  "title": "A2UI Common Types",
+  "description": "Common type definitions used across A2UI schemas.",
+  "$defs": {
+    "ComponentId": {
+      "type": "string",
+      "description": "The unique identifier for a component, used for both definitions and references within the same surface."
+    },
+    "AccessibilityAttributes": {
+      "type": "object",
+      "description": "Attributes to enhance accessibility when using assistive technologies like screen readers.",
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "A short string, typically 1 to 3 words, used by assistive technologies to convey the purpose or intent of an element. For example, an input field might have an accessible label of 'User ID' or a button might be labeled 'Submit'."
+        },
+        "description": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "Additional information provided by assistive technologies about an element such as instructions, format requirements, or result of an action. For example, a mute button might have a label of 'Mute' and a description of 'Silences notifications about this conversation'."
+        }
+      }
+    },
+    "ComponentCommon": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        }
+      },
+      "required": ["id"]
+    },
+    "ChildList": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ComponentId"
+          },
+          "description": "A static list of child component IDs."
+        },
+        {
+          "type": "object",
+          "description": "A template for generating a dynamic list of children from a data model list. The `componentId` is the component to use as a template.",
+          "properties": {
+            "componentId": {
+              "$ref": "#/$defs/ComponentId"
+            },
+            "path": {
+              "type": "string",
+              "description": "The path to the list of component property objects in the data model."
+            }
+          },
+          "required": ["componentId", "path"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "DataBinding": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "A JSON Pointer path to a value in the data model."
+        }
+      },
+      "required": ["path"],
+      "additionalProperties": false
+    },
+    "DynamicValue": {
+      "description": "A value that can be a literal, a path, or a function call returning any type.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "$ref": "#/$defs/FunctionCall"
+        }
+      ]
+    },
+    "DynamicString": {
+      "description": "Represents a string",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FunctionCall"
+            },
+            {
+              "properties": {
+                "returnType": {
+                  "const": "string"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "DynamicNumber": {
+      "description": "Represents a value that can be either a literal number, a path to a number in the data model, or a function call returning a number.",
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FunctionCall"
+            },
+            {
+              "properties": {
+                "returnType": {
+                  "const": "number"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "DynamicBoolean": {
+      "description": "A boolean value that can be a literal, a path, or a function call returning a boolean.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FunctionCall"
+            },
+            {
+              "properties": {
+                "returnType": {
+                  "const": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "DynamicStringList": {
+      "description": "Represents a value that can be either a literal array of strings, a path to a string array in the data model, or a function call returning a string array.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FunctionCall"
+            },
+            {
+              "properties": {
+                "returnType": {
+                  "const": "array"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "FunctionCall": {
+      "type": "object",
+      "description": "Invokes a named function on the client.",
+      "properties": {
+        "call": {
+          "type": "string",
+          "description": "The name of the function to call."
+        },
+        "args": {
+          "type": "object",
+          "description": "Arguments passed to the function.",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/DynamicValue"
+              },
+              {
+                "type": "object",
+                "description": "A literal object argument (e.g. configuration)."
+              }
+            ]
+          }
+        },
+        "returnType": {
+          "type": "string",
+          "description": "The expected return type of the function call.",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "array",
+            "object",
+            "any",
+            "void"
+          ],
+          "default": "boolean"
+        }
+      },
+      "required": ["call"],
+      "oneOf": [
+        { "$ref": "catalog.json#/$defs/anyFunction" }
+      ]
+    },
+    "CheckRule": {
+      "type": "object",
+      "description": "A single validation rule applied to an input component.",
+      "properties": {
+        "condition": {
+          "$ref": "#/$defs/DynamicBoolean"
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message to display if the check fails."
+        }
+      },
+      "required": ["condition", "message"],
+      "additionalProperties": false
+    },
+    "Checkable": {
+      "description": "Properties for components that support client-side checks.",
+      "type": "object",
+      "properties": {
+        "checks": {
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity.",
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          }
+        }
+      }
+    },
+    "Action": {
+      "description": "Defines an interaction handler that can either trigger a server-side event or execute a local client-side function.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Triggers a server-side event.",
+          "properties": {
+            "event": {
+              "type": "object",
+              "description": "The event to dispatch to the server.",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The name of the action to be dispatched to the server."
+                },
+                "context": {
+                  "type": "object",
+                  "description": "A JSON object containing the key-value pairs for the action context. Values can be literals or paths. Use literal values unless the value must be dynamically bound to the data model. Do NOT use paths for static IDs.",
+                  "additionalProperties": {
+                    "$ref": "#/$defs/DynamicValue"
+                  }
+                }
+              },
+              "required": ["name"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["event"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Executes a local client-side function.",
+          "properties": {
+            "functionCall": {
+              "$ref": "#/$defs/FunctionCall"
+            }
+          },
+          "required": ["functionCall"],
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/agent_sdks/go/schema/assets/0.9/server_to_client.json
+++ b/agent_sdks/go/schema/assets/0.9/server_to_client.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://a2ui.org/specification/v0_9/server_to_client.json",
+  "title": "A2UI Message Schema",
+  "description": "Describes a JSON payload for an A2UI (Agent to UI) message, which is used to dynamically construct and update user interfaces.",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/CreateSurfaceMessage" },
+    { "$ref": "#/$defs/UpdateComponentsMessage" },
+    { "$ref": "#/$defs/UpdateDataModelMessage" },
+    { "$ref": "#/$defs/DeleteSurfaceMessage" }
+  ],
+  "$defs": {
+    "CreateSurfaceMessage": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "const": "v0.9"
+        },
+        "createSurface": {
+          "type": "object",
+          "description": "Signals the client to create a new surface and begin rendering it. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
+          "properties": {
+            "surfaceId": {
+              "type": "string",
+              "description": "The unique identifier for the UI surface to be rendered."
+            },
+            "catalogId": {
+              "description": "A string that uniquely identifies this catalog. It is recommended to prefix this with an internet domain that you own, to avoid conflicts e.g. mycompany.com:somecatalog'.",
+              "type": "string"
+            },
+            "theme": {
+              "$ref": "catalog.json#/$defs/theme",
+              "description": "Theme parameters for the surface (e.g., {'primaryColor': '#FF0000'}). These must validate against the 'theme' schema defined in the catalog."
+            },
+            "sendDataModel": {
+              "type": "boolean",
+              "description": "If true, the client will send the full data model of this surface in the metadata of every A2A message sent to the server that created the surface. Defaults to false."
+            }
+          },
+          "required": ["surfaceId", "catalogId"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["createSurface", "version"],
+      "additionalProperties": false
+    },
+    "UpdateComponentsMessage": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "const": "v0.9"
+        },
+        "updateComponents": {
+          "type": "object",
+          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "properties": {
+            "surfaceId": {
+              "type": "string",
+              "description": "The unique identifier for the UI surface to be updated."
+            },
+
+            "components": {
+              "type": "array",
+              "description": "A list containing all UI components for the surface.",
+              "minItems": 1,
+              "items": {
+                "$ref": "catalog.json#/$defs/anyComponent"
+              }
+            }
+          },
+          "required": ["surfaceId", "components"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["updateComponents", "version"],
+      "additionalProperties": false
+    },
+    "UpdateDataModelMessage": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "const": "v0.9"
+        },
+        "updateDataModel": {
+          "type": "object",
+          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "properties": {
+            "surfaceId": {
+              "type": "string",
+              "description": "The unique identifier for the UI surface this data model update applies to."
+            },
+            "path": {
+              "type": "string",
+              "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model."
+            },
+            "value": {
+              "description": "The data to be updated in the data model. If present, the value at 'path' is replaced (or created). If omitted, the key at 'path' is removed.",
+              "additionalProperties": true
+            }
+          },
+          "required": ["surfaceId"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["updateDataModel", "version"],
+      "additionalProperties": false
+    },
+    "DeleteSurfaceMessage": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "const": "v0.9"
+        },
+        "deleteSurface": {
+          "type": "object",
+          "description": "Signals the client to delete the surface identified by 'surfaceId'. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "properties": {
+            "surfaceId": {
+              "type": "string",
+              "description": "The unique identifier for the UI surface to be deleted."
+            }
+          },
+          "required": ["surfaceId"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["deleteSurface", "version"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/agent_sdks/go/schema/catalog.go
+++ b/agent_sdks/go/schema/catalog.go
@@ -1,0 +1,472 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// CatalogConfig holds configuration for a catalog of components.
+type CatalogConfig struct {
+	// Name is the name of the catalog.
+	Name string
+	// Provider loads the catalog schema.
+	Provider A2uiCatalogProvider
+	// ExamplesPath is the path or glob pattern to the examples.
+	ExamplesPath string
+}
+
+// NewCatalogConfigFromPath creates a CatalogConfig that loads from a local path or file:// URI.
+func NewCatalogConfigFromPath(name, catalogPath string, examplesPath string) (*CatalogConfig, error) {
+	parsed, err := url.Parse(catalogPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid catalog path: %w", err)
+	}
+
+	var provider A2uiCatalogProvider
+	switch {
+	case parsed.Scheme == "" || parsed.Scheme == "file":
+		provider = &FileSystemCatalogProvider{Path: parsed.Path}
+	case parsed.Scheme == "http" || parsed.Scheme == "https":
+		return nil, fmt.Errorf("HTTP support is coming soon")
+	default:
+		return nil, fmt.Errorf("unsupported catalog URL scheme: %s", catalogPath)
+	}
+
+	resolvedExamples, err := resolveExamplesPath(examplesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CatalogConfig{
+		Name:         name,
+		Provider:     provider,
+		ExamplesPath: resolvedExamples,
+	}, nil
+}
+
+func resolveExamplesPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme == "" || parsed.Scheme == "file" {
+		return parsed.Path, nil
+	}
+	return "", fmt.Errorf("unsupported examples URL scheme: %s", path)
+}
+
+// collectRefs recursively collects all $ref values from a JSON object.
+func collectRefs(obj any) map[string]struct{} {
+	refs := make(map[string]struct{})
+	collectRefsRecursive(obj, refs)
+	return refs
+}
+
+func collectRefsRecursive(obj any, refs map[string]struct{}) {
+	switch v := obj.(type) {
+	case map[string]any:
+		for k, val := range v {
+			if k == "$ref" {
+				if s, ok := val.(string); ok {
+					refs[s] = struct{}{}
+				}
+			} else {
+				collectRefsRecursive(val, refs)
+			}
+		}
+	case []any:
+		for _, item := range v {
+			collectRefsRecursive(item, refs)
+		}
+	}
+}
+
+// pruneDefsByReachability prunes definitions not reachable from the provided roots.
+func pruneDefsByReachability(defs map[string]any, rootDefNames []string, internalRefPrefix string) map[string]any {
+	if internalRefPrefix == "" {
+		internalRefPrefix = "#/$defs/"
+	}
+
+	visited := make(map[string]struct{})
+	queue := make([]string, len(rootDefNames))
+	copy(queue, rootDefNames)
+
+	for len(queue) > 0 {
+		defName := queue[0]
+		queue = queue[1:]
+
+		defVal, exists := defs[defName]
+		if !exists {
+			continue
+		}
+		if _, seen := visited[defName]; seen {
+			continue
+		}
+		visited[defName] = struct{}{}
+
+		internalRefs := collectRefs(defVal)
+		for ref := range internalRefs {
+			if strings.HasPrefix(ref, internalRefPrefix) {
+				parts := strings.SplitAfter(ref, internalRefPrefix)
+				if len(parts) > 1 {
+					queue = append(queue, parts[len(parts)-1])
+				}
+			}
+		}
+	}
+
+	result := make(map[string]any, len(visited))
+	for k, v := range defs {
+		if _, ok := visited[k]; ok {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// A2uiCatalog represents a processed component catalog with its schema.
+type A2uiCatalog struct {
+	// Version is the version of the catalog.
+	Version string
+	// Name is the name of the catalog.
+	Name string
+	// S2CSchema is the server-to-client schema.
+	S2CSchema map[string]any
+	// CommonTypesSchema is the common types schema.
+	CommonTypesSchema map[string]any
+	// CatalogSchema is the catalog schema.
+	CatalogSchema map[string]any
+}
+
+// CatalogID returns the catalog ID from the catalog schema.
+func (c *A2uiCatalog) CatalogID() (string, error) {
+	id, ok := c.CatalogSchema[CatalogIDKey]
+	if !ok {
+		return "", fmt.Errorf("catalog '%s' missing catalogId", c.Name)
+	}
+	s, ok := id.(string)
+	if !ok {
+		return "", fmt.Errorf("catalog '%s' has non-string catalogId", c.Name)
+	}
+	return s, nil
+}
+
+// WithPruning returns a new catalog with pruned components and messages.
+func (c *A2uiCatalog) WithPruning(allowedComponents, allowedMessages []string) *A2uiCatalog {
+	catalog := c
+	if len(allowedComponents) > 0 {
+		catalog = catalog.withPrunedComponents(allowedComponents)
+	}
+	if len(allowedMessages) > 0 {
+		catalog = catalog.withPrunedMessages(allowedMessages)
+	}
+	return catalog.withPrunedCommonTypes()
+}
+
+func (c *A2uiCatalog) withPrunedComponents(allowedComponents []string) *A2uiCatalog {
+	if len(allowedComponents) == 0 {
+		return c
+	}
+
+	schemaCopy := deepCopyMap(c.CatalogSchema)
+	allowed := toSet(allowedComponents)
+
+	if comps, ok := schemaCopy[CatalogComponentsKey].(map[string]any); ok {
+		filtered := make(map[string]any, len(allowed))
+		for k, v := range comps {
+			if _, ok := allowed[k]; ok {
+				filtered[k] = v
+			}
+		}
+		schemaCopy[CatalogComponentsKey] = filtered
+	}
+
+	// Filter anyComponent oneOf
+	if defs, ok := schemaCopy["$defs"].(map[string]any); ok {
+		if anyComp, ok := defs["anyComponent"].(map[string]any); ok {
+			if oneOf, ok := anyComp["oneOf"].([]any); ok {
+				var filtered []any
+				prefix := fmt.Sprintf("#/%s/", CatalogComponentsKey)
+				for _, item := range oneOf {
+					itemMap, ok := item.(map[string]any)
+					if !ok {
+						continue
+					}
+					ref, ok := itemMap["$ref"].(string)
+					if !ok {
+						logger.Printf("skipping non-ref item in anyComponent oneOf: %v", item)
+						continue
+					}
+					if strings.HasPrefix(ref, prefix) {
+						parts := strings.Split(ref, "/")
+						compName := parts[len(parts)-1]
+						if _, ok := allowed[compName]; ok {
+							filtered = append(filtered, item)
+						}
+					} else {
+						logger.Printf("skipping unknown ref format: %s", ref)
+					}
+				}
+				anyComp["oneOf"] = filtered
+			}
+		}
+	}
+
+	return &A2uiCatalog{
+		Version:           c.Version,
+		Name:              c.Name,
+		S2CSchema:         c.S2CSchema,
+		CommonTypesSchema: c.CommonTypesSchema,
+		CatalogSchema:     schemaCopy,
+	}
+}
+
+func (c *A2uiCatalog) withPrunedMessages(allowedMessages []string) *A2uiCatalog {
+	if len(allowedMessages) == 0 {
+		return c
+	}
+
+	s2cCopy := deepCopyMap(c.S2CSchema)
+	allowed := toSet(allowedMessages)
+
+	if oneOf, ok := s2cCopy["oneOf"].([]any); ok {
+		var filtered []any
+		for _, item := range oneOf {
+			itemMap, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			ref, ok := itemMap["$ref"].(string)
+			if !ok || !strings.HasPrefix(ref, "#/$defs/") {
+				continue
+			}
+			parts := strings.Split(ref, "/")
+			name := parts[len(parts)-1]
+			if _, ok := allowed[name]; ok {
+				filtered = append(filtered, item)
+			}
+		}
+		s2cCopy["oneOf"] = filtered
+	}
+
+	if defs, ok := s2cCopy["$defs"].(map[string]any); ok {
+		rootNames := make([]string, 0, len(allowed))
+		for k := range allowed {
+			rootNames = append(rootNames, k)
+		}
+		s2cCopy["$defs"] = pruneDefsByReachability(defs, rootNames, "#/$defs/")
+	}
+
+	return &A2uiCatalog{
+		Version:           c.Version,
+		Name:              c.Name,
+		S2CSchema:         s2cCopy,
+		CommonTypesSchema: c.CommonTypesSchema,
+		CatalogSchema:     c.CatalogSchema,
+	}
+}
+
+func (c *A2uiCatalog) withPrunedCommonTypes() *A2uiCatalog {
+	if c.CommonTypesSchema == nil {
+		return c
+	}
+	defs, ok := c.CommonTypesSchema["$defs"].(map[string]any)
+	if !ok {
+		return c
+	}
+
+	externalRefs := collectRefs(c.CatalogSchema)
+	s2cRefs := collectRefs(c.S2CSchema)
+	for ref := range s2cRefs {
+		externalRefs[ref] = struct{}{}
+	}
+
+	var rootCommonTypes []string
+	for ref := range externalRefs {
+		if strings.HasPrefix(ref, "common_types.json#/$defs/") {
+			parts := strings.SplitAfter(ref, "#/$defs/")
+			if len(parts) > 1 {
+				rootCommonTypes = append(rootCommonTypes, parts[len(parts)-1])
+			}
+		}
+	}
+
+	newCommon := deepCopyMap(c.CommonTypesSchema)
+	newCommon["$defs"] = pruneDefsByReachability(defs, rootCommonTypes, "#/$defs/")
+
+	return &A2uiCatalog{
+		Version:           c.Version,
+		Name:              c.Name,
+		S2CSchema:         c.S2CSchema,
+		CommonTypesSchema: newCommon,
+		CatalogSchema:     c.CatalogSchema,
+	}
+}
+
+// RenderAsLLMInstructions renders the catalog and schema as LLM instructions.
+func (c *A2uiCatalog) RenderAsLLMInstructions() string {
+	var parts []string
+	parts = append(parts, A2UISchemaBlockStart)
+
+	s2cStr := "{}"
+	if c.S2CSchema != nil {
+		if b, err := json.MarshalIndent(c.S2CSchema, "", "  "); err == nil {
+			s2cStr = string(b)
+		}
+	}
+	parts = append(parts, fmt.Sprintf("### Server To Client Schema:\n%s", s2cStr))
+
+	if c.CommonTypesSchema != nil {
+		if defs, ok := c.CommonTypesSchema["$defs"].(map[string]any); ok && len(defs) > 0 {
+			if b, err := json.MarshalIndent(c.CommonTypesSchema, "", "  "); err == nil {
+				parts = append(parts, fmt.Sprintf("### Common Types Schema:\n%s", string(b)))
+			}
+		}
+	}
+
+	if b, err := json.MarshalIndent(c.CatalogSchema, "", "  "); err == nil {
+		parts = append(parts, fmt.Sprintf("### Catalog Schema:\n%s", string(b)))
+	}
+
+	parts = append(parts, A2UISchemaBlockEnd)
+	return strings.Join(parts, "\n\n")
+}
+
+// LoadExamples loads and optionally validates examples from a directory or glob pattern.
+func (c *A2uiCatalog) LoadExamples(path string, validate bool) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	return c.loadExamplesFromDisk(path, validate)
+}
+
+// loadExamplesFromDisk loads examples from the OS filesystem.
+func (c *A2uiCatalog) loadExamplesFromDisk(path string, validate bool) (string, error) {
+	pattern := path
+	info, err := os.Stat(path)
+	if err == nil && info.IsDir() {
+		pattern = filepath.Join(path, "*.json")
+	}
+
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", fmt.Errorf("invalid glob pattern %s: %w", pattern, err)
+	}
+
+	if len(matches) == 0 {
+		return "", nil
+	}
+
+	sort.Strings(matches)
+	return c.buildExamplesOutput(matches, validate, func(p string) ([]byte, error) {
+		return os.ReadFile(p)
+	}, func(p string) (bool, error) {
+		info, err := os.Stat(p)
+		if err != nil {
+			return false, err
+		}
+		return info.IsDir(), nil
+	})
+}
+
+// buildExamplesOutput builds the merged examples string from matched paths.
+func (c *A2uiCatalog) buildExamplesOutput(
+	matches []string,
+	validate bool,
+	readFile func(string) ([]byte, error),
+	isDir func(string) (bool, error),
+) (string, error) {
+	var validator *A2uiValidator
+	if validate {
+		validator = NewA2uiValidator(c)
+	}
+
+	var merged []string
+	for _, fullPath := range matches {
+		if dir, err := isDir(fullPath); err != nil || dir {
+			continue
+		}
+		basename := strings.TrimSuffix(filepath.Base(fullPath), filepath.Ext(fullPath))
+		content, err := readFile(fullPath)
+		if err != nil {
+			continue
+		}
+
+		if validator != nil {
+			var jsonData any
+			if err := json.Unmarshal(content, &jsonData); err != nil {
+				return "", fmt.Errorf("failed to validate example %s: %w", fullPath, err)
+			}
+			if err := validator.Validate(jsonData, "", false); err != nil {
+				return "", fmt.Errorf("failed to validate example %s: %w", fullPath, err)
+			}
+		}
+
+		merged = append(merged, fmt.Sprintf("---BEGIN %s---\n%s\n---END %s---", basename, string(content), basename))
+	}
+
+	if len(merged) == 0 {
+		return "", nil
+	}
+	return strings.Join(merged, "\n\n"), nil
+}
+
+// deepCopyMap creates a deep copy of a map[string]any using recursive traversal.
+func deepCopyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		result[k] = deepCopyAny(v)
+	}
+	return result
+}
+
+// deepCopyAny creates a deep copy of any JSON-compatible value.
+func deepCopyAny(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		return deepCopyMap(val)
+	case []any:
+		s := make([]any, len(val))
+		for i, item := range val {
+			s[i] = deepCopyAny(item)
+		}
+		return s
+	default:
+		return v
+	}
+}
+
+// toSet converts a string slice to a set (map[string]struct{}).
+func toSet(items []string) map[string]struct{} {
+	s := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		s[item] = struct{}{}
+	}
+	return s
+}

--- a/agent_sdks/go/schema/catalog_provider.go
+++ b/agent_sdks/go/schema/catalog_provider.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package schema provides A2UI catalog schemas and resource loading.
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// A2uiCatalogProvider is the interface for loading catalog definitions.
+type A2uiCatalogProvider interface {
+	// Load loads a catalog definition and returns it as a map.
+	Load() (map[string]any, error)
+}
+
+// FileSystemCatalogProvider loads catalog definitions from the local filesystem.
+type FileSystemCatalogProvider struct {
+	Path string
+}
+
+// Load reads and parses a JSON catalog file from the filesystem.
+func (p *FileSystemCatalogProvider) Load() (map[string]any, error) {
+	data, err := os.ReadFile(p.Path)
+	if err != nil {
+		return nil, fmt.Errorf("could not load schema from %s: %w", p.Path, err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("could not parse schema from %s: %w", p.Path, err)
+	}
+
+	return result, nil
+}
+
+// RawCatalogProvider loads a catalog definition from raw JSON bytes.
+type RawCatalogProvider struct {
+	Data []byte
+}
+
+// Load parses the raw JSON bytes into a catalog definition map.
+func (p *RawCatalogProvider) Load() (map[string]any, error) {
+	var result map[string]any
+	if err := json.Unmarshal(p.Data, &result); err != nil {
+		return nil, fmt.Errorf("could not parse raw catalog JSON: %w", err)
+	}
+	return result, nil
+}

--- a/agent_sdks/go/schema/catalog_test.go
+++ b/agent_sdks/go/schema/catalog_test.go
@@ -1,0 +1,578 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCatalogIDProperty(t *testing.T) {
+	catalogID := "https://a2ui.org/basic_catalog.json"
+	catalog := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         map[string]any{},
+		CommonTypesSchema: map[string]any{},
+		CatalogSchema:     map[string]any{"catalogId": catalogID},
+	}
+	id, err := catalog.CatalogID()
+	if err != nil {
+		t.Fatalf("CatalogID() returned error: %v", err)
+	}
+	if id != catalogID {
+		t.Errorf("CatalogID() = %q, want %q", id, catalogID)
+	}
+}
+
+func TestCatalogIDMissingRaisesError(t *testing.T) {
+	catalog := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         map[string]any{},
+		CommonTypesSchema: map[string]any{},
+		CatalogSchema:     map[string]any{}, // No catalogId
+	}
+	_, err := catalog.CatalogID()
+	if err == nil {
+		t.Fatal("expected error for missing catalogId")
+	}
+	if !strings.Contains(err.Error(), "missing catalogId") {
+		t.Errorf("expected 'missing catalogId' error, got: %v", err)
+	}
+}
+
+func TestLoadExamples(t *testing.T) {
+	tmpDir := t.TempDir()
+	exampleDir := filepath.Join(tmpDir, "examples")
+	if err := os.Mkdir(exampleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	os.WriteFile(filepath.Join(exampleDir, "example1.json"),
+		[]byte(`[{"beginRendering": {"surfaceId": "id"}}]`), 0644)
+	os.WriteFile(filepath.Join(exampleDir, "example2.json"),
+		[]byte(`[{"beginRendering": {"surfaceId": "id"}}]`), 0644)
+	os.WriteFile(filepath.Join(exampleDir, "ignored.txt"),
+		[]byte("should not be loaded"), 0644)
+
+	catalog := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         map[string]any{},
+		CommonTypesSchema: map[string]any{},
+		CatalogSchema:     map[string]any{},
+	}
+
+	examplesStr, err := catalog.LoadExamples(exampleDir, false)
+	if err != nil {
+		t.Fatalf("LoadExamples failed: %v", err)
+	}
+	if !strings.Contains(examplesStr, "---BEGIN example1---") {
+		t.Error("expected example1 in output")
+	}
+	if !strings.Contains(examplesStr, "---BEGIN example2---") {
+		t.Error("expected example2 in output")
+	}
+	if strings.Contains(examplesStr, "ignored") {
+		t.Error("expected ignored.txt to be excluded")
+	}
+}
+
+func TestLoadExamplesValidationFailsOnBadJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	exampleDir := filepath.Join(tmpDir, "examples")
+	os.Mkdir(exampleDir, 0755)
+	os.WriteFile(filepath.Join(exampleDir, "bad.json"),
+		[]byte("{ this is bad json }"), 0644)
+
+	catalog := &A2uiCatalog{
+		Version:       Version09,
+		Name:          "basic",
+		S2CSchema:     map[string]any{},
+		CatalogSchema: map[string]any{"catalogId": "basic"},
+	}
+
+	_, err := catalog.LoadExamples(exampleDir, true)
+	if err == nil {
+		t.Fatal("expected error for bad JSON example")
+	}
+	if !strings.Contains(err.Error(), "bad.json") {
+		t.Errorf("expected error mentioning bad.json, got: %v", err)
+	}
+}
+
+func TestLoadExamplesEmptyPath(t *testing.T) {
+	catalog := &A2uiCatalog{
+		Version:       Version09,
+		Name:          "basic",
+		S2CSchema:     map[string]any{},
+		CatalogSchema: map[string]any{},
+	}
+
+	result, err := catalog.LoadExamples("", false)
+	if err != nil {
+		t.Fatalf("LoadExamples with empty path failed: %v", err)
+	}
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+func TestLoadExamplesNonExistentPath(t *testing.T) {
+	catalog := &A2uiCatalog{
+		Version:       Version09,
+		Name:          "basic",
+		S2CSchema:     map[string]any{},
+		CatalogSchema: map[string]any{},
+	}
+
+	result, err := catalog.LoadExamples("/non/existent/path", false)
+	if err != nil {
+		t.Fatalf("LoadExamples with non-existent path failed: %v", err)
+	}
+	if result != "" {
+		t.Errorf("expected empty string for non-existent path, got %q", result)
+	}
+}
+
+func TestWithPruningComponents(t *testing.T) {
+	catalogSchema := map[string]any{
+		"catalogId": "basic",
+		"components": map[string]any{
+			"Text":   map[string]any{"type": "object"},
+			"Button": map[string]any{"type": "object"},
+			"Image":  map[string]any{"type": "object"},
+		},
+	}
+	catalog := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         map[string]any{},
+		CommonTypesSchema: map[string]any{},
+		CatalogSchema:     catalogSchema,
+	}
+
+	pruned := catalog.WithPruning([]string{"Text", "Button"}, nil)
+	prunedComps := pruned.CatalogSchema["components"].(map[string]any)
+	if _, ok := prunedComps["Text"]; !ok {
+		t.Error("expected Text in pruned components")
+	}
+	if _, ok := prunedComps["Button"]; !ok {
+		t.Error("expected Button in pruned components")
+	}
+	if _, ok := prunedComps["Image"]; ok {
+		t.Error("Image should be pruned")
+	}
+	// Should be a new instance
+	if pruned == catalog {
+		t.Error("pruned should be a new instance")
+	}
+
+	// Test anyComponent oneOf filtering
+	catalogSchemaWithDefs := map[string]any{
+		"catalogId": "basic",
+		"$defs": map[string]any{
+			"anyComponent": map[string]any{
+				"oneOf": []any{
+					map[string]any{"$ref": "#/components/Text"},
+					map[string]any{"$ref": "#/components/Button"},
+					map[string]any{"$ref": "#/components/Image"},
+				},
+			},
+		},
+		"components": map[string]any{
+			"Text":   map[string]any{},
+			"Button": map[string]any{},
+			"Image":  map[string]any{},
+		},
+	}
+	catalogWithDefs := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         map[string]any{},
+		CommonTypesSchema: map[string]any{},
+		CatalogSchema:     catalogSchemaWithDefs,
+	}
+
+	prunedDefs := catalogWithDefs.WithPruning([]string{"Text"}, nil)
+	anyComp := prunedDefs.CatalogSchema["$defs"].(map[string]any)["anyComponent"].(map[string]any)
+	oneOf := anyComp["oneOf"].([]any)
+	if len(oneOf) != 1 {
+		t.Fatalf("expected 1 oneOf entry, got %d", len(oneOf))
+	}
+	ref := oneOf[0].(map[string]any)["$ref"].(string)
+	if ref != "#/components/Text" {
+		t.Errorf("expected #/components/Text, got %q", ref)
+	}
+
+	// Test empty allowed components
+	emptyPruned := catalog.WithPruning(nil, nil)
+	if emptyPruned.CatalogSchema == nil {
+		t.Error("expected non-nil CatalogSchema")
+	}
+}
+
+func TestWithPruningMessages(t *testing.T) {
+	s2cSchema := map[string]any{
+		"oneOf": []any{
+			map[string]any{"$ref": "#/$defs/MessageA"},
+			map[string]any{"$ref": "#/$defs/MessageB"},
+			map[string]any{"$ref": "#/$defs/MessageC"},
+		},
+		"$defs": map[string]any{
+			"MessageA": map[string]any{"type": "object", "properties": map[string]any{"a": map[string]any{"type": "string"}}},
+			"MessageB": map[string]any{"type": "object", "properties": map[string]any{"b": map[string]any{"type": "string"}}},
+			"MessageC": map[string]any{"type": "object", "properties": map[string]any{"c": map[string]any{"type": "string"}}},
+		},
+	}
+	catalog := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         s2cSchema,
+		CommonTypesSchema: map[string]any{},
+		CatalogSchema:     map[string]any{"catalogId": "basic"},
+	}
+
+	pruned := catalog.WithPruning(nil, []string{"MessageA", "MessageC"})
+	prunedS2C := pruned.S2CSchema
+	oneOf := prunedS2C["oneOf"].([]any)
+	if len(oneOf) != 2 {
+		t.Fatalf("expected 2 oneOf entries, got %d", len(oneOf))
+	}
+
+	prunedDefs := prunedS2C["$defs"].(map[string]any)
+	if _, ok := prunedDefs["MessageA"]; !ok {
+		t.Error("expected MessageA in pruned defs")
+	}
+	if _, ok := prunedDefs["MessageC"]; !ok {
+		t.Error("expected MessageC in pruned defs")
+	}
+	if _, ok := prunedDefs["MessageB"]; ok {
+		t.Error("MessageB should be pruned from defs")
+	}
+}
+
+func TestWithPruningMessagesInternalReachability(t *testing.T) {
+	s2cSchema := map[string]any{
+		"oneOf": []any{
+			map[string]any{"$ref": "#/$defs/MessageA"},
+		},
+		"$defs": map[string]any{
+			"MessageA":   map[string]any{"type": "object", "properties": map[string]any{"shared": map[string]any{"$ref": "#/$defs/SharedType"}}},
+			"SharedType": map[string]any{"type": "string"},
+			"UnusedType": map[string]any{"type": "number"},
+		},
+	}
+	catalog := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         s2cSchema,
+		CommonTypesSchema: map[string]any{},
+		CatalogSchema:     map[string]any{"catalogId": "basic"},
+	}
+
+	pruned := catalog.WithPruning(nil, []string{"MessageA"})
+	prunedDefs := pruned.S2CSchema["$defs"].(map[string]any)
+	if _, ok := prunedDefs["MessageA"]; !ok {
+		t.Error("expected MessageA in pruned defs")
+	}
+	if _, ok := prunedDefs["SharedType"]; !ok {
+		t.Error("expected SharedType in pruned defs (reachable from MessageA)")
+	}
+	if _, ok := prunedDefs["UnusedType"]; ok {
+		t.Error("UnusedType should be pruned (unreachable)")
+	}
+}
+
+func TestRenderAsLLMInstructions(t *testing.T) {
+	catalog := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         map[string]any{"s2c": "schema"},
+		CommonTypesSchema: map[string]any{"$defs": map[string]any{"common": "types"}},
+		CatalogSchema: map[string]any{
+			"$schema":   "https://json-schema.org/draft/2020-12/schema",
+			"catalog":   "schema",
+			"catalogId": "id_basic",
+		},
+	}
+
+	schemaStr := catalog.RenderAsLLMInstructions()
+	if !strings.Contains(schemaStr, A2UISchemaBlockStart) {
+		t.Error("expected schema block start")
+	}
+	if !strings.Contains(schemaStr, "### Server To Client Schema:") {
+		t.Error("expected server to client schema header")
+	}
+	if !strings.Contains(schemaStr, `"s2c": "schema"`) {
+		t.Error("expected s2c schema content")
+	}
+	if !strings.Contains(schemaStr, "### Common Types Schema:") {
+		t.Error("expected common types schema header")
+	}
+	if !strings.Contains(schemaStr, "### Catalog Schema:") {
+		t.Error("expected catalog schema header")
+	}
+	if !strings.Contains(schemaStr, A2UISchemaBlockEnd) {
+		t.Error("expected schema block end")
+	}
+}
+
+func TestRenderAsLLMInstructionsDropsEmptyCommonTypes(t *testing.T) {
+	// Empty common_types_schema
+	catalog := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         map[string]any{"s2c": "schema"},
+		CommonTypesSchema: map[string]any{},
+		CatalogSchema:     map[string]any{"catalogId": "id_basic"},
+	}
+	schemaStr := catalog.RenderAsLLMInstructions()
+	if strings.Contains(schemaStr, "### Common Types Schema:") {
+		t.Error("empty common types should be dropped")
+	}
+
+	// common_types_schema with empty $defs
+	catalog2 := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         map[string]any{"s2c": "schema"},
+		CommonTypesSchema: map[string]any{"$defs": map[string]any{}},
+		CatalogSchema:     map[string]any{"catalogId": "id_basic"},
+	}
+	schemaStr2 := catalog2.RenderAsLLMInstructions()
+	if strings.Contains(schemaStr2, "### Common Types Schema:") {
+		t.Error("empty $defs common types should be dropped")
+	}
+}
+
+func TestWithPruningCommonTypes(t *testing.T) {
+	commonTypes := map[string]any{
+		"$defs": map[string]any{
+			"TypeForCompA": map[string]any{"type": "string"},
+			"TypeForCompB": map[string]any{"type": "number"},
+		},
+	}
+	catalogSchema := map[string]any{
+		"catalogId": "basic",
+		"components": map[string]any{
+			"CompA": map[string]any{"$ref": "common_types.json#/$defs/TypeForCompA"},
+			"CompB": map[string]any{"$ref": "common_types.json#/$defs/TypeForCompB"},
+		},
+	}
+	catalog := &A2uiCatalog{
+		Version:           Version09,
+		Name:              "basic",
+		S2CSchema:         map[string]any{},
+		CommonTypesSchema: commonTypes,
+		CatalogSchema:     catalogSchema,
+	}
+
+	pruned := catalog.WithPruning([]string{"CompA"}, nil)
+	prunedDefs := pruned.CommonTypesSchema["$defs"].(map[string]any)
+
+	if _, ok := prunedDefs["TypeForCompA"]; !ok {
+		t.Error("expected TypeForCompA in pruned common types")
+	}
+	if _, ok := prunedDefs["TypeForCompB"]; ok {
+		t.Error("TypeForCompB should be pruned from common types")
+	}
+}
+
+func TestLoadExamplesWithGlob(t *testing.T) {
+	tmpDir := t.TempDir()
+	exampleDir := filepath.Join(tmpDir, "examples")
+	os.Mkdir(exampleDir, 0755)
+
+	os.WriteFile(filepath.Join(exampleDir, "top.json"),
+		[]byte(`[{"beginRendering": {"surfaceId": "top"}}]`), 0644)
+	os.WriteFile(filepath.Join(exampleDir, "ignored.txt"),
+		[]byte("not json"), 0644)
+
+	catalog := &A2uiCatalog{
+		Version:       Version09,
+		Name:          "basic",
+		S2CSchema:     map[string]any{},
+		CatalogSchema: map[string]any{},
+	}
+
+	// Match only *.json
+	examples, err := catalog.LoadExamples(filepath.Join(exampleDir, "*.json"), false)
+	if err != nil {
+		t.Fatalf("LoadExamples failed: %v", err)
+	}
+	if !strings.Contains(examples, "---BEGIN top---") {
+		t.Error("expected top.json in output")
+	}
+	if strings.Contains(examples, "ignored") {
+		t.Error("expected ignored.txt to be excluded")
+	}
+}
+
+func TestLoadExamplesWithGlobPrefixSuffix(t *testing.T) {
+	tmpDir := t.TempDir()
+	exampleDir := filepath.Join(tmpDir, "examples")
+	os.Mkdir(exampleDir, 0755)
+
+	os.WriteFile(filepath.Join(exampleDir, "user_profile.json"),
+		[]byte(`[{"beginRendering": {"surfaceId": "user"}}]`), 0644)
+	os.WriteFile(filepath.Join(exampleDir, "user_settings.json"),
+		[]byte(`[{"beginRendering": {"surfaceId": "settings"}}]`), 0644)
+	os.WriteFile(filepath.Join(exampleDir, "admin_profile.json"),
+		[]byte(`[{"beginRendering": {"surfaceId": "admin"}}]`), 0644)
+
+	catalog := &A2uiCatalog{
+		Version:       Version09,
+		Name:          "basic",
+		S2CSchema:     map[string]any{},
+		CatalogSchema: map[string]any{},
+	}
+
+	// Filter by prefix: user_*.json
+	userExamples, err := catalog.LoadExamples(filepath.Join(exampleDir, "user_*.json"), false)
+	if err != nil {
+		t.Fatalf("LoadExamples failed: %v", err)
+	}
+	if !strings.Contains(userExamples, "---BEGIN user_profile---") {
+		t.Error("expected user_profile in output")
+	}
+	if !strings.Contains(userExamples, "---BEGIN user_settings---") {
+		t.Error("expected user_settings in output")
+	}
+	if strings.Contains(userExamples, "admin_profile") {
+		t.Error("expected admin_profile to be excluded")
+	}
+}
+
+func TestLoadExamplesWithGlobAdvancedCases(t *testing.T) {
+	tmpDir := t.TempDir()
+	exampleDir := filepath.Join(tmpDir, "examples")
+	os.Mkdir(exampleDir, 0755)
+
+	os.WriteFile(filepath.Join(exampleDir, "step1.json"),
+		[]byte(`[{"beginRendering": {"surfaceId": "1"}}]`), 0644)
+	os.WriteFile(filepath.Join(exampleDir, "step2.json"),
+		[]byte(`[{"beginRendering": {"surfaceId": "2"}}]`), 0644)
+	os.WriteFile(filepath.Join(exampleDir, "step3.json"),
+		[]byte(`[{"beginRendering": {"surfaceId": "3"}}]`), 0644)
+
+	// Create a directory named *.json that should be skipped
+	os.Mkdir(filepath.Join(exampleDir, "directory.json"), 0755)
+
+	catalog := &A2uiCatalog{
+		Version:       Version09,
+		Name:          "basic",
+		S2CSchema:     map[string]any{},
+		CatalogSchema: map[string]any{},
+	}
+
+	// Test that directory matching *.json is skipped correctly
+	allExamples, err := catalog.LoadExamples(filepath.Join(exampleDir, "*.json"), false)
+	if err != nil {
+		t.Fatalf("LoadExamples failed: %v", err)
+	}
+	if !strings.Contains(allExamples, "---BEGIN step1---") {
+		t.Error("expected step1 in output")
+	}
+	if strings.Contains(allExamples, "directory") {
+		t.Error("directory.json dir should be skipped")
+	}
+
+	// Test zero matches returns empty string
+	result, err := catalog.LoadExamples(filepath.Join(exampleDir, "*.yaml"), false)
+	if err != nil {
+		t.Fatalf("LoadExamples failed: %v", err)
+	}
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+func TestCatalogConfigFromPathSchemes(t *testing.T) {
+	// Test local path
+	config, err := NewCatalogConfigFromPath("test_file", "relative_path/to/catalog.json", "")
+	if err != nil {
+		t.Fatalf("NewCatalogConfigFromPath failed: %v", err)
+	}
+	if fsp, ok := config.Provider.(*FileSystemCatalogProvider); ok {
+		if fsp.Path != "relative_path/to/catalog.json" {
+			t.Errorf("expected path 'relative_path/to/catalog.json', got %q", fsp.Path)
+		}
+	} else {
+		t.Error("expected FileSystemCatalogProvider")
+	}
+
+	// Test file:// scheme
+	config, err = NewCatalogConfigFromPath("test_file", "file:///absolute_path/to/catalog.json", "")
+	if err != nil {
+		t.Fatalf("NewCatalogConfigFromPath failed: %v", err)
+	}
+	if fsp, ok := config.Provider.(*FileSystemCatalogProvider); ok {
+		if fsp.Path != "/absolute_path/to/catalog.json" {
+			t.Errorf("expected path '/absolute_path/to/catalog.json', got %q", fsp.Path)
+		}
+	}
+
+	// Test HTTP raises error
+	_, err = NewCatalogConfigFromPath("test_http", "http://a2ui.org/catalog.json", "")
+	if err == nil {
+		t.Fatal("expected error for HTTP scheme")
+	}
+	if !strings.Contains(err.Error(), "HTTP support is coming soon") {
+		t.Errorf("expected HTTP not supported error, got: %v", err)
+	}
+
+	// Test unsupported scheme
+	_, err = NewCatalogConfigFromPath("test_ftp", "ftp://a2ui.org/catalog.json", "")
+	if err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+	errStr := strings.ToLower(err.Error())
+	if !strings.Contains(errStr, "unsupported") {
+		t.Errorf("expected unsupported scheme error, got: %v", err)
+	}
+}
+
+func TestResolveExamplesPath(t *testing.T) {
+	// Empty path
+	result, err := resolveExamplesPath("")
+	if err != nil || result != "" {
+		t.Errorf("expected empty result for empty path, got %q, err %v", result, err)
+	}
+
+	// Absolute path
+	result, err = resolveExamplesPath("/absolute/examples")
+	if err != nil || result != "/absolute/examples" {
+		t.Errorf("expected /absolute/examples, got %q, err %v", result, err)
+	}
+
+	// file:// scheme
+	result, err = resolveExamplesPath("file:///absolute/examples")
+	if err != nil || result != "/absolute/examples" {
+		t.Errorf("expected /absolute/examples, got %q, err %v", result, err)
+	}
+
+	// Unsupported scheme
+	_, err = resolveExamplesPath("https://a2ui.org/examples")
+	if err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+}
+
+

--- a/agent_sdks/go/schema/common_modifiers.go
+++ b/agent_sdks/go/schema/common_modifiers.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+// RemoveStrictValidation recursively removes additionalProperties: false
+// from a JSON schema, making it more lenient for LLM-generated output.
+func RemoveStrictValidation(schema any) any {
+	switch v := schema.(type) {
+	case map[string]any:
+		newSchema := make(map[string]any, len(v))
+		for k, val := range v {
+			newSchema[k] = RemoveStrictValidation(val)
+		}
+		if ap, ok := newSchema["additionalProperties"]; ok {
+			if b, isBool := ap.(bool); isBool && !b {
+				delete(newSchema, "additionalProperties")
+			}
+		}
+		return newSchema
+	case []any:
+		result := make([]any, len(v))
+		for i, item := range v {
+			result[i] = RemoveStrictValidation(item)
+		}
+		return result
+	default:
+		return schema
+	}
+}

--- a/agent_sdks/go/schema/common_modifiers_test.go
+++ b/agent_sdks/go/schema/common_modifiers_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+)
+
+func TestRemoveStrictValidation(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"a": map[string]any{"type": "string", "additionalProperties": false},
+			"b": map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "object", "additionalProperties": false},
+			},
+		},
+		"additionalProperties": false,
+	}
+
+	modified := RemoveStrictValidation(schema)
+	modifiedMap := modified.(map[string]any)
+
+	// Check that additionalProperties: false is removed at top level
+	if _, ok := modifiedMap["additionalProperties"]; ok {
+		t.Error("additionalProperties should be removed at top level")
+	}
+
+	// Check nested property "a"
+	props := modifiedMap["properties"].(map[string]any)
+	a := props["a"].(map[string]any)
+	if _, ok := a["additionalProperties"]; ok {
+		t.Error("additionalProperties should be removed from property 'a'")
+	}
+
+	// Check deeply nested items
+	b := props["b"].(map[string]any)
+	items := b["items"].(map[string]any)
+	if _, ok := items["additionalProperties"]; ok {
+		t.Error("additionalProperties should be removed from b.items")
+	}
+
+	// Check that original is not mutated
+	if schema["additionalProperties"] != false {
+		t.Error("original schema should not be mutated")
+	}
+	origProps := schema["properties"].(map[string]any)
+	origA := origProps["a"].(map[string]any)
+	if origA["additionalProperties"] != false {
+		t.Error("original nested schema should not be mutated")
+	}
+}
+
+func TestRemoveStrictValidationPreservesTrue(t *testing.T) {
+	schema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": true,
+	}
+
+	modified := RemoveStrictValidation(schema)
+	modifiedMap := modified.(map[string]any)
+
+	// additionalProperties: true should be preserved
+	if val, ok := modifiedMap["additionalProperties"]; !ok || val != true {
+		t.Error("additionalProperties: true should be preserved")
+	}
+}
+
+func TestRemoveStrictValidationArray(t *testing.T) {
+	schema := []any{
+		map[string]any{"additionalProperties": false, "type": "object"},
+		map[string]any{"additionalProperties": true, "type": "string"},
+	}
+
+	modified := RemoveStrictValidation(schema)
+	modifiedArr := modified.([]any)
+
+	first := modifiedArr[0].(map[string]any)
+	if _, ok := first["additionalProperties"]; ok {
+		t.Error("additionalProperties: false should be removed from array element")
+	}
+
+	second := modifiedArr[1].(map[string]any)
+	if val, ok := second["additionalProperties"]; !ok || val != true {
+		t.Error("additionalProperties: true should be preserved in array element")
+	}
+}
+
+func TestRemoveStrictValidationPrimitive(t *testing.T) {
+	// Primitive values should pass through unchanged
+	if RemoveStrictValidation("hello") != "hello" {
+		t.Error("string should pass through unchanged")
+	}
+	if RemoveStrictValidation(42) != 42 {
+		t.Error("int should pass through unchanged")
+	}
+	if RemoveStrictValidation(nil) != nil {
+		t.Error("nil should pass through unchanged")
+	}
+}

--- a/agent_sdks/go/schema/constants.go
+++ b/agent_sdks/go/schema/constants.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import "fmt"
+
+// Asset package and resource keys.
+const (
+	ServerToClientSchemaKey = "server_to_client"
+	CommonTypesSchemaKey    = "common_types"
+	CatalogSchemaKey        = "catalog"
+	CatalogComponentsKey    = "components"
+	CatalogIDKey            = "catalogId"
+	CatalogStylesKey        = "styles"
+	SurfaceIDKey            = "surfaceId"
+)
+
+// Protocol constants.
+const (
+	SupportedCatalogIDsKey    = "supportedCatalogIds"
+	InlineCatalogsKey         = "inlineCatalogs"
+	A2UIClientCapabilitiesKey = "a2uiClientCapabilities"
+)
+
+// Schema URL and catalog naming.
+const (
+	BaseSchemaURL     = "https://a2ui.org/"
+	InlineCatalogName = "inline"
+)
+
+// Supported versions.
+const (
+	Version09 = "0.9"
+)
+
+// SpecVersionMap maps version strings to their schema resource paths.
+var SpecVersionMap = map[string]map[string]string{
+	Version09: {
+		ServerToClientSchemaKey: "specification/v0_9/json/server_to_client.json",
+		CommonTypesSchemaKey:    "specification/v0_9/json/common_types.json",
+	},
+}
+
+const SpecificationDir = "specification"
+
+// Tags and delimiters.
+const (
+	A2UIOpenTag  = "<a2ui-json>"
+	A2UICloseTag = "</a2ui-json>"
+
+	A2UISchemaBlockStart = "---BEGIN A2UI JSON SCHEMA---"
+	A2UISchemaBlockEnd   = "---END A2UI JSON SCHEMA---"
+)
+
+// DefaultWorkflowRules is the default set of workflow rules for LLM output.
+var DefaultWorkflowRules = fmt.Sprintf(`The generated response MUST follow these rules:
+- The response can contain one or more A2UI JSON blocks.
+- Each A2UI JSON block MUST be wrapped in %s and %s tags.
+- Between or around these blocks, you can provide conversational text.
+- The JSON part MUST be a single, raw JSON object (usually a list of A2UI messages) and MUST validate against the provided A2UI JSON SCHEMA.
+- Top-Down Component Ordering: Within the `+"`components`"+` list of a message:
+    - The 'root' component MUST be the FIRST element.
+    - Parent components MUST appear before their child components.
+    This specific ordering allows the streaming parser to yield and render the UI incrementally as it arrives.`, A2UIOpenTag, A2UICloseTag)

--- a/agent_sdks/go/schema/logger.go
+++ b/agent_sdks/go/schema/logger.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"io"
+	"log"
+)
+
+// logger is the package-level logger. It defaults to discarding all output.
+// Use SetLogger to enable logging.
+var logger = log.New(io.Discard, "[a2ui-schema] ", log.LstdFlags)
+
+// SetLogger sets the logger used by the schema package.
+// Pass nil to disable logging.
+func SetLogger(l *log.Logger) {
+	if l == nil {
+		logger = log.New(io.Discard, "[a2ui-schema] ", log.LstdFlags)
+		return
+	}
+	logger = l
+}

--- a/agent_sdks/go/schema/manager.go
+++ b/agent_sdks/go/schema/manager.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AGenUI/AGenUI/agent_sdks/go"
+)
+
+// SchemaModifier is a function that transforms a schema map.
+type SchemaModifier func(map[string]any) map[string]any
+
+// A2uiSchemaManager manages A2UI schema levels and prompt injection.
+// It implements the a2ui.InferenceStrategy interface.
+type A2uiSchemaManager struct {
+	version               string
+	acceptsInlineCatalogs bool
+	serverToClientSchema  map[string]any
+	commonTypesSchema     map[string]any
+	supportedCatalogs     []*A2uiCatalog
+	catalogExamplePaths   map[string]string
+	schemaModifiers       []SchemaModifier
+}
+
+// A2uiSchemaManagerConfig holds configuration for creating an A2uiSchemaManager.
+type A2uiSchemaManagerConfig struct {
+	Version               string
+	Catalogs              []*CatalogConfig
+	AcceptsInlineCatalogs bool
+	SchemaModifiers       []SchemaModifier
+}
+
+// NewA2uiSchemaManager creates a new A2uiSchemaManager.
+func NewA2uiSchemaManager(cfg A2uiSchemaManagerConfig) (*A2uiSchemaManager, error) {
+	m := &A2uiSchemaManager{
+		version:               cfg.Version,
+		acceptsInlineCatalogs: cfg.AcceptsInlineCatalogs,
+		catalogExamplePaths:   make(map[string]string),
+		schemaModifiers:       cfg.SchemaModifiers,
+	}
+
+	if err := m.loadSchemas(cfg.Version, cfg.Catalogs); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// AcceptsInlineCatalogs returns whether the manager accepts inline catalogs.
+func (m *A2uiSchemaManager) AcceptsInlineCatalogs() bool {
+	return m.acceptsInlineCatalogs
+}
+
+// SupportedCatalogIDs returns the list of supported catalog IDs.
+func (m *A2uiSchemaManager) SupportedCatalogIDs() []string {
+	var ids []string
+	for _, c := range m.supportedCatalogs {
+		if id, err := c.CatalogID(); err == nil {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func (m *A2uiSchemaManager) applyModifiers(schema map[string]any) map[string]any {
+	for _, modifier := range m.schemaModifiers {
+		schema = modifier(schema)
+	}
+	return schema
+}
+
+func (m *A2uiSchemaManager) loadSchemas(version string, catalogs []*CatalogConfig) error {
+	if _, ok := SpecVersionMap[version]; !ok {
+		return fmt.Errorf("unknown A2UI specification version: %s. Supported: %v", version, supportedVersions())
+	}
+
+	// Load server-to-client schema
+	s2c, err := LoadFromBundledResource(version, ServerToClientSchemaKey, SpecVersionMap)
+	if err != nil {
+		return fmt.Errorf("failed to load server-to-client schema: %w", err)
+	}
+	if s2c != nil {
+		m.serverToClientSchema = m.applyModifiers(s2c)
+	}
+
+	// Load common types schema
+	ct, err := LoadFromBundledResource(version, CommonTypesSchemaKey, SpecVersionMap)
+	if err != nil {
+		return fmt.Errorf("failed to load common types schema: %w", err)
+	}
+	if ct != nil {
+		m.commonTypesSchema = m.applyModifiers(ct)
+	}
+
+	// Process catalogs
+	for _, config := range catalogs {
+		catalogSchema, err := config.Provider.Load()
+		if err != nil {
+			return fmt.Errorf("failed to load catalog '%s': %w", config.Name, err)
+		}
+		catalogSchema = m.applyModifiers(catalogSchema)
+
+		catalog := &A2uiCatalog{
+			Version:           version,
+			Name:              config.Name,
+			CatalogSchema:     catalogSchema,
+			S2CSchema:         m.serverToClientSchema,
+			CommonTypesSchema: m.commonTypesSchema,
+		}
+		m.supportedCatalogs = append(m.supportedCatalogs, catalog)
+
+		catalogID, err := catalog.CatalogID()
+		if err == nil {
+			m.catalogExamplePaths[catalogID] = config.ExamplesPath
+		}
+	}
+
+	return nil
+}
+
+// selectCatalog selects the component catalog based on client capabilities.
+func (m *A2uiSchemaManager) selectCatalog(clientUICapabilities map[string]any) (*A2uiCatalog, error) {
+	if len(m.supportedCatalogs) == 0 {
+		return nil, fmt.Errorf("no supported catalogs found")
+	}
+
+	if len(clientUICapabilities) == 0 {
+		return m.supportedCatalogs[0], nil
+	}
+
+	inlineCatalogs, _ := clientUICapabilities[InlineCatalogsKey].([]any)
+	clientSupportedIDs, _ := clientUICapabilities[SupportedCatalogIDsKey].([]any)
+
+	if !m.acceptsInlineCatalogs && len(inlineCatalogs) > 0 {
+		return nil, fmt.Errorf("inline catalog '%s' is provided in client UI capabilities, but the agent does not accept inline catalogs", InlineCatalogsKey)
+	}
+
+	if len(inlineCatalogs) > 0 {
+		baseCatalog := m.supportedCatalogs[0]
+		if len(clientSupportedIDs) > 0 {
+			agentCatalogs := m.catalogsByID()
+			for _, cscid := range clientSupportedIDs {
+				if id, ok := cscid.(string); ok {
+					if c, exists := agentCatalogs[id]; exists {
+						baseCatalog = c
+						break
+					}
+				}
+			}
+		}
+
+		mergedSchema := deepCopyMap(baseCatalog.CatalogSchema)
+		for _, inlineCatalogRaw := range inlineCatalogs {
+			inlineCatalogSchema, ok := inlineCatalogRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+			inlineCatalogSchema = m.applyModifiers(inlineCatalogSchema)
+			if inlineComps, ok := inlineCatalogSchema[CatalogComponentsKey].(map[string]any); ok {
+				if mergedComps, ok := mergedSchema[CatalogComponentsKey].(map[string]any); ok {
+					for k, v := range inlineComps {
+						mergedComps[k] = v
+					}
+				}
+			}
+			// Merge $defs from inline catalog so that local $ref references remain valid.
+			if inlineDefs, ok := inlineCatalogSchema["$defs"].(map[string]any); ok {
+				if mergedDefs, ok := mergedSchema["$defs"].(map[string]any); ok {
+					for k, v := range inlineDefs {
+						mergedDefs[k] = v
+					}
+				} else {
+					mergedSchema["$defs"] = deepCopyMap(inlineDefs)
+				}
+			}
+		}
+
+		return &A2uiCatalog{
+			Version:           m.version,
+			Name:              InlineCatalogName,
+			CatalogSchema:     mergedSchema,
+			S2CSchema:         m.serverToClientSchema,
+			CommonTypesSchema: m.commonTypesSchema,
+		}, nil
+	}
+
+	if len(clientSupportedIDs) == 0 {
+		return m.supportedCatalogs[0], nil
+	}
+
+	agentCatalogs := m.catalogsByID()
+	for _, cscid := range clientSupportedIDs {
+		if id, ok := cscid.(string); ok {
+			if c, exists := agentCatalogs[id]; exists {
+				return c, nil
+			}
+		}
+	}
+
+	var agentIDs []string
+	for _, c := range m.supportedCatalogs {
+		if id, err := c.CatalogID(); err == nil {
+			agentIDs = append(agentIDs, id)
+		}
+	}
+	return nil, fmt.Errorf("no client-supported catalog found on the agent side. Agent-supported catalogs are: %v", agentIDs)
+}
+
+func (m *A2uiSchemaManager) catalogsByID() map[string]*A2uiCatalog {
+	result := make(map[string]*A2uiCatalog, len(m.supportedCatalogs))
+	for _, c := range m.supportedCatalogs {
+		if id, err := c.CatalogID(); err == nil {
+			result[id] = c
+		}
+	}
+	return result
+}
+
+// GetSelectedCatalog gets the selected catalog after selection and component pruning.
+func (m *A2uiSchemaManager) GetSelectedCatalog(clientUICapabilities map[string]any, allowedComponents, allowedMessages []string) (*A2uiCatalog, error) {
+	catalog, err := m.selectCatalog(clientUICapabilities)
+	if err != nil {
+		return nil, err
+	}
+	return catalog.WithPruning(allowedComponents, allowedMessages), nil
+}
+
+// LoadExamples loads examples for a catalog.
+func (m *A2uiSchemaManager) LoadExamples(catalog *A2uiCatalog, validate bool) (string, error) {
+	catalogID, err := catalog.CatalogID()
+	if err != nil {
+		return "", nil
+	}
+	if path, ok := m.catalogExamplePaths[catalogID]; ok {
+		return catalog.LoadExamples(path, validate)
+	}
+	return "", nil
+}
+
+// GenerateSystemPrompt assembles the final system instruction for the LLM.
+// This method implements the a2ui.InferenceStrategy interface.
+func (m *A2uiSchemaManager) GenerateSystemPrompt(opts a2ui.SystemPromptOptions) string {
+	var parts []string
+	parts = append(parts, opts.RoleDescription)
+
+	workflow := DefaultWorkflowRules
+	if opts.WorkflowDescription != "" {
+		workflow += opts.WorkflowDescription
+	}
+	parts = append(parts, fmt.Sprintf("## Workflow Description:\n%s", workflow))
+
+	if opts.UIDescription != "" {
+		parts = append(parts, fmt.Sprintf("## UI Description:\n%s", opts.UIDescription))
+	}
+
+	selectedCatalog, err := m.GetSelectedCatalog(
+		opts.ClientUICapabilities,
+		opts.AllowedComponents,
+		opts.AllowedMessages,
+	)
+	if err != nil {
+		// If catalog selection fails, continue without schema
+		parts = append(parts, fmt.Sprintf("<!-- Warning: catalog selection failed: %s -->", err.Error()))
+	} else {
+		if opts.IncludeSchema {
+			parts = append(parts, selectedCatalog.RenderAsLLMInstructions())
+		}
+
+		if opts.IncludeExamples {
+			examplesStr, err := m.LoadExamples(selectedCatalog, opts.ValidateExamples)
+			if err == nil && examplesStr != "" {
+				parts = append(parts, fmt.Sprintf("### Examples:\n%s", examplesStr))
+			}
+		}
+	}
+
+	return strings.Join(parts, "\n\n")
+}
+
+func supportedVersions() []string {
+	versions := make([]string, 0, len(SpecVersionMap))
+	for k := range SpecVersionMap {
+		versions = append(versions, k)
+	}
+	return versions
+}
+
+// Ensure A2uiSchemaManager implements a2ui.InferenceStrategy at compile time.
+var _ a2ui.InferenceStrategy = (*A2uiSchemaManager)(nil)

--- a/agent_sdks/go/schema/manager_test.go
+++ b/agent_sdks/go/schema/manager_test.go
@@ -1,0 +1,533 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	a2ui "github.com/AGenUI/AGenUI/agent_sdks/go"
+)
+
+// mockCatalogProvider returns a predefined catalog schema.
+type mockCatalogProvider struct {
+	Schema map[string]any
+}
+
+func (p *mockCatalogProvider) Load() (map[string]any, error) {
+	return p.Schema, nil
+}
+
+func newTestManager(t *testing.T, catalogs []*CatalogConfig, opts ...func(*A2uiSchemaManagerConfig)) *A2uiSchemaManager {
+	t.Helper()
+	cfg := A2uiSchemaManagerConfig{
+		Version:  Version09,
+		Catalogs: catalogs,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	m, err := NewA2uiSchemaManager(cfg)
+	if err != nil {
+		t.Fatalf("NewA2uiSchemaManager failed: %v", err)
+	}
+	return m
+}
+
+func TestSchemaManagerInitInvalidVersion(t *testing.T) {
+	_, err := NewA2uiSchemaManager(A2uiSchemaManagerConfig{
+		Version: "invalid_version",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid version")
+	}
+	if !strings.Contains(err.Error(), "Unknown A2UI specification version") &&
+		!strings.Contains(err.Error(), "unknown A2UI specification version") {
+		t.Errorf("expected version error, got: %v", err)
+	}
+}
+
+func TestSchemaManagerInitWithCatalog(t *testing.T) {
+	catalogSchema := map[string]any{
+		"$schema":   "https://json-schema.org/draft/2020-12/schema",
+		"catalogId": "test-catalog",
+		"components": map[string]any{
+			"Text": map[string]any{"type": "object"},
+		},
+	}
+	config := &CatalogConfig{
+		Name:     "test",
+		Provider: &mockCatalogProvider{Schema: catalogSchema},
+	}
+
+	m := newTestManager(t, []*CatalogConfig{config})
+
+	if len(m.supportedCatalogs) != 1 {
+		t.Fatalf("expected 1 catalog, got %d", len(m.supportedCatalogs))
+	}
+	if m.supportedCatalogs[0].Name != "test" {
+		t.Errorf("expected catalog name 'test', got %q", m.supportedCatalogs[0].Name)
+	}
+	comps := m.supportedCatalogs[0].CatalogSchema["components"].(map[string]any)
+	if _, ok := comps["Text"]; !ok {
+		t.Error("expected Text component in catalog")
+	}
+}
+
+func TestSchemaManagerSupportedCatalogIDs(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "test",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId": "id_test",
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+	ids := m.SupportedCatalogIDs()
+	if len(ids) != 1 || ids[0] != "id_test" {
+		t.Errorf("expected [id_test], got %v", ids)
+	}
+}
+
+func TestSelectCatalogDefault(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId": "id_basic",
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+
+	// No capabilities -> returns first catalog
+	catalog, err := m.selectCatalog(nil)
+	if err != nil {
+		t.Fatalf("selectCatalog failed: %v", err)
+	}
+	if catalog.Name != "basic" {
+		t.Errorf("expected 'basic', got %q", catalog.Name)
+	}
+
+	// Empty capabilities -> returns first catalog
+	catalog, err = m.selectCatalog(map[string]any{})
+	if err != nil {
+		t.Fatalf("selectCatalog failed: %v", err)
+	}
+	if catalog.Name != "basic" {
+		t.Errorf("expected 'basic', got %q", catalog.Name)
+	}
+}
+
+func TestSelectCatalogBySupportedIDs(t *testing.T) {
+	basic := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId": "id_basic",
+		}},
+	}
+	custom := &CatalogConfig{
+		Name: "custom",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId": "id_custom",
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{basic, custom})
+
+	// Select custom by ID
+	catalog, err := m.selectCatalog(map[string]any{
+		SupportedCatalogIDsKey: []any{"id_custom"},
+	})
+	if err != nil {
+		t.Fatalf("selectCatalog failed: %v", err)
+	}
+	if catalog.Name != "custom" {
+		t.Errorf("expected 'custom', got %q", catalog.Name)
+	}
+
+	// Priority follows client's order
+	catalog, err = m.selectCatalog(map[string]any{
+		SupportedCatalogIDsKey: []any{"id_custom", "id_basic"},
+	})
+	if err != nil {
+		t.Fatalf("selectCatalog failed: %v", err)
+	}
+	if catalog.Name != "custom" {
+		t.Errorf("expected 'custom' (first match), got %q", catalog.Name)
+	}
+}
+
+func TestSelectCatalogNoMatch(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId": "id_basic",
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+
+	_, err := m.selectCatalog(map[string]any{
+		SupportedCatalogIDsKey: []any{"id_not_exists"},
+	})
+	if err == nil {
+		t.Fatal("expected error for no matching catalog")
+	}
+	if !strings.Contains(err.Error(), "No client-supported catalog found") &&
+		!strings.Contains(err.Error(), "no client-supported catalog found") {
+		t.Errorf("expected no match error, got: %v", err)
+	}
+}
+
+func TestSelectCatalogInline(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId":  "id_basic",
+			"components": map[string]any{"Text": map[string]any{}},
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config}, func(cfg *A2uiSchemaManagerConfig) {
+		cfg.AcceptsInlineCatalogs = true
+	})
+
+	inlineSchema := map[string]any{
+		"components": map[string]any{"Button": map[string]any{}},
+	}
+	catalog, err := m.selectCatalog(map[string]any{
+		InlineCatalogsKey: []any{inlineSchema},
+	})
+	if err != nil {
+		t.Fatalf("selectCatalog failed: %v", err)
+	}
+	if catalog.Name != InlineCatalogName {
+		t.Errorf("expected '%s', got %q", InlineCatalogName, catalog.Name)
+	}
+	// Should have merged components
+	comps := catalog.CatalogSchema["components"].(map[string]any)
+	if _, ok := comps["Text"]; !ok {
+		t.Error("expected Text from base catalog")
+	}
+	if _, ok := comps["Button"]; !ok {
+		t.Error("expected Button from inline catalog")
+	}
+}
+
+func TestSelectCatalogInlineNotAccepted(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId": "id_basic",
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+	// AcceptsInlineCatalogs defaults to false
+
+	_, err := m.selectCatalog(map[string]any{
+		InlineCatalogsKey: []any{map[string]any{"components": map[string]any{}}},
+	})
+	if err == nil {
+		t.Fatal("expected error for inline catalogs not accepted")
+	}
+	if !strings.Contains(err.Error(), "does not accept inline catalogs") {
+		t.Errorf("expected inline catalogs error, got: %v", err)
+	}
+}
+
+func TestSelectCatalogNoCatalogs(t *testing.T) {
+	m := newTestManager(t, nil)
+	_, err := m.selectCatalog(nil)
+	if err == nil {
+		t.Fatal("expected error for no supported catalogs")
+	}
+	if !strings.Contains(err.Error(), "no supported catalogs found") {
+		t.Errorf("expected no catalogs error, got: %v", err)
+	}
+}
+
+func TestGetSelectedCatalog(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId": "id_basic",
+			"components": map[string]any{
+				"Text":   map[string]any{},
+				"Button": map[string]any{},
+			},
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+
+	catalog, err := m.GetSelectedCatalog(nil, []string{"Text"}, nil)
+	if err != nil {
+		t.Fatalf("GetSelectedCatalog failed: %v", err)
+	}
+	comps := catalog.CatalogSchema["components"].(map[string]any)
+	if _, ok := comps["Text"]; !ok {
+		t.Error("expected Text in pruned components")
+	}
+	if _, ok := comps["Button"]; ok {
+		t.Error("Button should be pruned")
+	}
+}
+
+func TestGenerateSystemPrompt(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId":  "id_basic",
+			"components": map[string]any{"Text": map[string]any{}},
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+
+	prompt := m.GenerateSystemPrompt(a2ui.SystemPromptOptions{
+		RoleDescription:     "You are a helpful assistant.",
+		WorkflowDescription: "Manage workflow.",
+		UIDescription:       "Render UI.",
+		IncludeSchema:       true,
+	})
+
+	if !strings.Contains(prompt, "You are a helpful assistant.") {
+		t.Error("expected role description in prompt")
+	}
+	if !strings.Contains(prompt, "## Workflow Description:") {
+		t.Error("expected workflow description header")
+	}
+	if !strings.Contains(prompt, "Manage workflow.") {
+		t.Error("expected workflow description in prompt")
+	}
+	if !strings.Contains(prompt, "## UI Description:") {
+		t.Error("expected UI description header")
+	}
+	if !strings.Contains(prompt, "Render UI.") {
+		t.Error("expected UI description in prompt")
+	}
+	if !strings.Contains(prompt, A2UISchemaBlockStart) {
+		t.Error("expected schema block start in prompt")
+	}
+	if !strings.Contains(prompt, "### Server To Client Schema:") {
+		t.Error("expected server to client schema header")
+	}
+	if !strings.Contains(prompt, A2UISchemaBlockEnd) {
+		t.Error("expected schema block end in prompt")
+	}
+}
+
+func TestGenerateSystemPromptMinimalArgs(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId":  "id_basic",
+			"components": map[string]any{},
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+
+	prompt := m.GenerateSystemPrompt(a2ui.SystemPromptOptions{
+		RoleDescription: "Just Role",
+	})
+
+	if !strings.Contains(prompt, "Just Role") {
+		t.Error("expected role description in prompt")
+	}
+	if !strings.Contains(prompt, "## Workflow Description:") {
+		t.Error("expected default workflow description")
+	}
+	if !strings.Contains(prompt, DefaultWorkflowRules) {
+		t.Error("expected default workflow rules in prompt")
+	}
+	if strings.Contains(prompt, "## UI Description:") {
+		t.Error("UI description should not be present without ui_description arg")
+	}
+	if strings.Contains(prompt, A2UISchemaBlockStart) {
+		t.Error("schema block should not be present without include_schema")
+	}
+}
+
+func TestGenerateSystemPromptCustomWorkflowAppending(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId":  "id_basic",
+			"components": map[string]any{},
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+
+	customRule := "Custom Rule Content"
+	prompt := m.GenerateSystemPrompt(a2ui.SystemPromptOptions{
+		RoleDescription:     "Role",
+		WorkflowDescription: customRule,
+	})
+
+	if !strings.Contains(prompt, DefaultWorkflowRules) {
+		t.Error("expected default workflow rules")
+	}
+	if !strings.Contains(prompt, customRule) {
+		t.Error("expected custom rule in prompt")
+	}
+	// Custom rule should be appended after default
+	defaultIdx := strings.Index(prompt, DefaultWorkflowRules)
+	customIdx := strings.Index(prompt, customRule)
+	if customIdx <= defaultIdx {
+		t.Error("custom rule should appear after default workflow rules")
+	}
+}
+
+func TestGenerateSystemPromptWithExamples(t *testing.T) {
+	tmpDir := t.TempDir()
+	exampleDir := filepath.Join(tmpDir, "examples")
+	os.Mkdir(exampleDir, 0755)
+	os.WriteFile(filepath.Join(exampleDir, "example1.json"),
+		[]byte(`[{"version": "v0.9", "createSurface": {"surfaceId": "id", "catalogId": "basic"}}]`), 0644)
+
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId":  "id_basic",
+			"components": map[string]any{},
+		}},
+		ExamplesPath: exampleDir,
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+
+	prompt := m.GenerateSystemPrompt(a2ui.SystemPromptOptions{
+		RoleDescription: "Role description",
+		IncludeExamples: true,
+	})
+
+	if !strings.Contains(prompt, "### Examples:") {
+		t.Error("expected examples section in prompt")
+	}
+	if !strings.Contains(prompt, "example1") {
+		t.Error("expected example1 in prompt")
+	}
+}
+
+func TestManagerWithModifiers(t *testing.T) {
+	// Create a modifier that converts all "type" values to "modified"
+	modifier := func(schema map[string]any) map[string]any {
+		return RemoveStrictValidation(schema).(map[string]any)
+	}
+
+	catalogData, _ := json.Marshal(map[string]any{
+		"catalogId":            "test",
+		"additionalProperties": false,
+		"components":           map[string]any{},
+	})
+
+	config := &CatalogConfig{
+		Name:     "test",
+		Provider: &RawCatalogProvider{Data: catalogData},
+	}
+
+	m := newTestManager(t, []*CatalogConfig{config}, func(cfg *A2uiSchemaManagerConfig) {
+		cfg.SchemaModifiers = []SchemaModifier{modifier}
+	})
+
+	// Verify modifiers were applied to catalog
+	catalog := m.supportedCatalogs[0]
+	if _, ok := catalog.CatalogSchema["additionalProperties"]; ok {
+		t.Error("additionalProperties should be removed by modifier")
+	}
+}
+
+func TestManagerAcceptsInlineCatalogs(t *testing.T) {
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId": "id_basic",
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{config}, func(cfg *A2uiSchemaManagerConfig) {
+		cfg.AcceptsInlineCatalogs = true
+	})
+	if !m.AcceptsInlineCatalogs() {
+		t.Error("expected AcceptsInlineCatalogs to be true")
+	}
+
+	m2 := newTestManager(t, []*CatalogConfig{config})
+	if m2.AcceptsInlineCatalogs() {
+		t.Error("expected AcceptsInlineCatalogs to be false by default")
+	}
+}
+
+func TestSelectCatalogInlineWithSupportedIDs(t *testing.T) {
+	basic := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId":  "id_basic",
+			"components": map[string]any{"BasicComp": map[string]any{}},
+		}},
+	}
+	custom := &CatalogConfig{
+		Name: "custom",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId":  "id_custom",
+			"components": map[string]any{"CustomComp": map[string]any{}},
+		}},
+	}
+	m := newTestManager(t, []*CatalogConfig{basic, custom}, func(cfg *A2uiSchemaManagerConfig) {
+		cfg.AcceptsInlineCatalogs = true
+	})
+
+	// Inline with supportedCatalogIds should use id_custom as base
+	catalog, err := m.selectCatalog(map[string]any{
+		InlineCatalogsKey:      []any{map[string]any{"components": map[string]any{"InlineComp": map[string]any{}}}},
+		SupportedCatalogIDsKey: []any{"id_custom"},
+	})
+	if err != nil {
+		t.Fatalf("selectCatalog failed: %v", err)
+	}
+	if catalog.Name != InlineCatalogName {
+		t.Errorf("expected '%s', got %q", InlineCatalogName, catalog.Name)
+	}
+	comps := catalog.CatalogSchema["components"].(map[string]any)
+	// Base should be custom (has CustomComp)
+	if _, ok := comps["CustomComp"]; !ok {
+		t.Error("expected CustomComp from custom base catalog")
+	}
+	if _, ok := comps["InlineComp"]; !ok {
+		t.Error("expected InlineComp from inline catalog")
+	}
+}
+
+func TestLoadExamplesForCatalog(t *testing.T) {
+	tmpDir := t.TempDir()
+	exampleDir := filepath.Join(tmpDir, "examples")
+	os.Mkdir(exampleDir, 0755)
+	os.WriteFile(filepath.Join(exampleDir, "ex.json"),
+		[]byte(`[{"version": "v0.9", "createSurface": {"surfaceId": "id", "catalogId": "basic"}}]`), 0644)
+
+	config := &CatalogConfig{
+		Name: "basic",
+		Provider: &mockCatalogProvider{Schema: map[string]any{
+			"catalogId":  "id_basic",
+			"components": map[string]any{},
+		}},
+		ExamplesPath: exampleDir,
+	}
+	m := newTestManager(t, []*CatalogConfig{config})
+
+	catalog := m.supportedCatalogs[0]
+	examples, err := m.LoadExamples(catalog, false)
+	if err != nil {
+		t.Fatalf("LoadExamples failed: %v", err)
+	}
+	if !strings.Contains(examples, "---BEGIN ex---") {
+		t.Error("expected example in output")
+	}
+}

--- a/agent_sdks/go/schema/utils.go
+++ b/agent_sdks/go/schema/utils.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+// LoadFromBundledResource loads a schema resource from the embedded assets.
+func LoadFromBundledResource(version, resourceKey string, specMap map[string]map[string]string) (map[string]any, error) {
+	versionMap, ok := specMap[version]
+	if !ok {
+		return nil, fmt.Errorf("unknown A2UI version: %s", version)
+	}
+
+	relPath, ok := versionMap[resourceKey]
+	if !ok {
+		return nil, nil // Resource key not present in spec version map; callers treat nil as "not available".
+	}
+
+	filename := filepath.Base(relPath)
+
+	// Load from embedded assets
+	assetPath := fmt.Sprintf("assets/%s/%s", version, filename)
+	data, err := assetsFS.ReadFile(assetPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not load schema %s for version %s: %w", filename, version, err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("could not parse schema %s: %w", filename, err)
+	}
+
+	return result, nil
+}
+
+

--- a/agent_sdks/go/schema/validator.go
+++ b/agent_sdks/go/schema/validator.go
@@ -1,0 +1,886 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
+)
+
+// Recursion limits.
+const (
+	MaxGlobalDepth   = 50
+	MaxFuncCallDepth = 5
+)
+
+// Component field names.
+const (
+	FieldComponents   = "components"
+	FieldID           = "id"
+	FieldRoot         = "root"
+	FieldPath         = "path"
+	FieldFunctionCall = "functionCall"
+	FieldCall         = "call"
+	FieldArgs         = "args"
+)
+
+// RelaxedPathPattern is an A2UI relaxed path pattern (extends RFC 6901 to support relative paths).
+var RelaxedPathPattern = regexp.MustCompile(
+	`^(?:(?:/(?:[^~/]|~[01])*)*|(?:[^~/]|~[01])+(?:/(?:[^~/]|~[01])*)*)$`,
+)
+
+// RefFieldsMap maps component names to their (singleRefFields, listRefFields).
+type RefFieldsMap map[string]RefFields
+
+// RefFields holds the single and list reference field names for a component type.
+type RefFields struct {
+	SingleRefs map[string]struct{}
+	ListRefs   map[string]struct{}
+}
+
+// A2uiValidator validates A2UI JSON payloads against the schema and checks integrity.
+type A2uiValidator struct {
+	catalog  *A2uiCatalog
+	version  string
+	compiler *jsonschema.Compiler
+}
+
+// NewA2uiValidator creates a new validator for the given catalog.
+func NewA2uiValidator(catalog *A2uiCatalog) *A2uiValidator {
+	version := Version09
+	if catalog != nil {
+		version = catalog.Version
+	}
+	v := &A2uiValidator{
+		catalog: catalog,
+		version: version,
+	}
+	v.compiler = v.buildCompiler()
+	return v
+}
+
+// buildCompiler sets up a JSON Schema compiler with all schema resources registered.
+func (v *A2uiValidator) buildCompiler() *jsonschema.Compiler {
+	if v.catalog == nil {
+		return nil
+	}
+	c := jsonschema.NewCompiler()
+
+	baseURI := BaseSchemaURL
+	if v.catalog.S2CSchema != nil {
+		if id, ok := v.catalog.S2CSchema["$id"].(string); ok {
+			baseURI = id
+		}
+	}
+
+	// Derive sibling URIs from the base URI.
+	base := baseURI
+	if idx := strings.LastIndex(base, "/"); idx >= 0 {
+		base = base[:idx+1]
+	}
+	catalogURI := base + "catalog.json"
+	commonTypesURI := base + "common_types.json"
+
+	// Register schemas. We re-marshal and re-parse through jsonschema.UnmarshalJSON
+	// so the compiler receives the types it expects (e.g. json.Number).
+	addResource := func(uri string, schema map[string]any) {
+		if schema == nil {
+			return
+		}
+		data, err := json.Marshal(schema)
+		if err != nil {
+			return
+		}
+		doc, err := jsonschema.UnmarshalJSON(strings.NewReader(string(data)))
+		if err != nil {
+			return
+		}
+		_ = c.AddResource(uri, doc)
+	}
+
+	addResource(baseURI, v.catalog.S2CSchema)
+	addResource(catalogURI, v.catalog.CatalogSchema)
+	addResource(commonTypesURI, v.catalog.CommonTypesSchema)
+
+	// Fallbacks for relative references.
+	addResource("catalog.json", v.catalog.CatalogSchema)
+	addResource("common_types.json", v.catalog.CommonTypesSchema)
+
+	// Register catalog by its catalogId if different.
+	if catalogID, err := v.catalog.CatalogID(); err == nil && catalogID != catalogURI {
+		addResource(catalogID, v.catalog.CatalogSchema)
+	}
+
+	return c
+}
+
+// Validate validates an A2UI message or list of messages.
+func (v *A2uiValidator) Validate(a2uiJSON any, rootID string, strictIntegrity bool) error {
+	var messages []map[string]any
+	switch val := a2uiJSON.(type) {
+	case []any:
+		for _, item := range val {
+			if m, ok := item.(map[string]any); ok {
+				messages = append(messages, m)
+			}
+		}
+	case map[string]any:
+		messages = []map[string]any{val}
+	default:
+		return fmt.Errorf("a2ui_json must be a dict or list")
+	}
+
+	if v.version == Version09 {
+		return v.validate09Custom(messages, rootID, strictIntegrity)
+	}
+
+	// Fallback for non-0.9 versions: integrity checks only.
+	for _, message := range messages {
+		var components []any
+		var surfaceID string
+		if uc, ok := message["updateComponents"].(map[string]any); ok {
+			components, _ = toAnySlice(uc[FieldComponents])
+			surfaceID, _ = uc[SurfaceIDKey].(string)
+		}
+		if len(components) > 0 {
+			compList := toComponentList(components)
+			refMap := ExtractComponentRefFields(v.catalog)
+			if fid := findRootID(messages, surfaceID); fid != "" {
+				rootID = fid
+			}
+			if err := ValidateComponentIntegrity(rootID, compList, refMap, !strictIntegrity); err != nil {
+				return err
+			}
+			if _, err := AnalyzeTopology(rootID, compList, refMap, strictIntegrity); err != nil {
+				return err
+			}
+		}
+		if err := ValidateRecursionAndPaths(message); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validate09Custom performs per-message JSON Schema validation followed by integrity checks,
+func (v *A2uiValidator) validate09Custom(messages []map[string]any, rootID string, strictIntegrity bool) error {
+	// Phase 1: JSON Schema validation per message.
+	var allErrors []string
+	for idx, message := range messages {
+		if _, ok := message["createSurface"]; ok {
+			allErrors = append(allErrors, v.getSubSchemaErrors("CreateSurfaceMessage", message, fmt.Sprintf("messages[%d]", idx))...)
+		} else if _, ok := message["updateComponents"]; ok {
+			allErrors = append(allErrors, v.getUpdateComponentsErrors(message, fmt.Sprintf("messages[%d]", idx))...)
+		} else if _, ok := message["updateDataModel"]; ok {
+			allErrors = append(allErrors, v.getSubSchemaErrors("UpdateDataModelMessage", message, fmt.Sprintf("messages[%d]", idx))...)
+		} else if _, ok := message["deleteSurface"]; ok {
+			allErrors = append(allErrors, v.getSubSchemaErrors("DeleteSurfaceMessage", message, fmt.Sprintf("messages[%d]", idx))...)
+		} else {
+			keys := make([]string, 0, len(message))
+			for k := range message {
+				keys = append(keys, k)
+			}
+			allErrors = append(allErrors, fmt.Sprintf("messages[%d]: Unknown message type with keys %v", idx, keys))
+		}
+	}
+	if len(allErrors) > 0 {
+		var sb strings.Builder
+		sb.WriteString("Validation failed:")
+		for _, e := range allErrors {
+			sb.WriteString("\n  - ")
+			sb.WriteString(e)
+		}
+		return fmt.Errorf("%s", sb.String())
+	}
+
+	// Phase 2: Integrity checks (component IDs, topology, recursion, paths).
+	for _, message := range messages {
+		var components []any
+		var surfaceID string
+		if uc, ok := message["updateComponents"].(map[string]any); ok {
+			components, _ = toAnySlice(uc[FieldComponents])
+			surfaceID, _ = uc[SurfaceIDKey].(string)
+		}
+		if len(components) > 0 {
+			compList := toComponentList(components)
+			refMap := ExtractComponentRefFields(v.catalog)
+			if fid := findRootID(messages, surfaceID); fid != "" {
+				rootID = fid
+			}
+			if err := ValidateComponentIntegrity(rootID, compList, refMap, !strictIntegrity); err != nil {
+				return err
+			}
+			if _, err := AnalyzeTopology(rootID, compList, refMap, strictIntegrity); err != nil {
+				return err
+			}
+		}
+		if err := ValidateRecursionAndPaths(message); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getSubSchemaErrors validates a message against s2c $defs sub-schema.
+func (v *A2uiValidator) getSubSchemaErrors(defName string, instance map[string]any, basePath string) []string {
+	if v.compiler == nil || v.catalog == nil || v.catalog.S2CSchema == nil {
+		return nil
+	}
+
+	s2cID, _ := v.catalog.S2CSchema["$id"].(string)
+	if s2cID == "" {
+		s2cID = BaseSchemaURL
+	}
+	ref := s2cID + "#/$defs/" + defName
+
+	sch, err := v.compiler.Compile(ref)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: failed to compile schema for %s: %s", basePath, defName, err)}
+	}
+
+	inst := toJSONSchemaValue(instance)
+	return formatValidationErrors(sch, inst, basePath)
+}
+
+// getUpdateComponentsErrors validates an updateComponents message, checking
+// structure and validating each component against its catalog schema.
+func (v *A2uiValidator) getUpdateComponentsErrors(message map[string]any, path string) []string {
+	var errors []string
+
+	if ver, _ := message["version"].(string); ver != "v0.9" {
+		errors = append(errors, fmt.Sprintf("%s: Invalid version, expected 'v0.9'", path))
+	}
+
+	uc, ok := message["updateComponents"].(map[string]any)
+	if !ok {
+		errors = append(errors, fmt.Sprintf("%s: Expected updateComponents to be an object", path))
+		return errors
+	}
+
+	if sid, ok := uc["surfaceId"].(string); !ok || sid == "" {
+		errors = append(errors, fmt.Sprintf("%s.updateComponents: Invalid or missing surfaceId", path))
+	}
+
+	components, cOk := toAnySlice(uc["components"])
+	if !cOk {
+		errors = append(errors, fmt.Sprintf("%s.updateComponents: Expected components to be an array", path))
+		return errors
+	}
+
+	for idx, comp := range components {
+		compMap, ok := comp.(map[string]any)
+		if !ok {
+			errors = append(errors, fmt.Sprintf("%s.updateComponents.components[%d]: Component is not an object", path, idx))
+			continue
+		}
+		compID, _ := compMap[FieldID].(string)
+		var compPath string
+		if compID != "" {
+			compPath = fmt.Sprintf("%s.updateComponents.components[id='%s']", path, compID)
+		} else {
+			compPath = fmt.Sprintf("%s.updateComponents.components[%d]", path, idx)
+		}
+		errors = append(errors, v.getSingleComponentErrors(compMap, compPath)...)
+	}
+	return errors
+}
+
+// getSingleComponentErrors validates a single component against catalog.json#/components/{type}.
+func (v *A2uiValidator) getSingleComponentErrors(comp map[string]any, path string) []string {
+	compType, _ := comp["component"].(string)
+	if compType == "" {
+		return []string{fmt.Sprintf("%s: Missing 'component' field", path)}
+	}
+
+	if v.catalog == nil || v.catalog.CatalogSchema == nil {
+		return []string{fmt.Sprintf("%s: Catalog schema or components missing", path)}
+	}
+
+	allComponents, _ := v.catalog.CatalogSchema[CatalogComponentsKey].(map[string]any)
+	if _, exists := allComponents[compType]; !exists {
+		return []string{fmt.Sprintf("%s: Unknown component: %s", path, compType)}
+	}
+
+	if v.compiler == nil {
+		return nil
+	}
+
+	// Build a $ref to the component schema in catalog.json, same as Python:
+	// {"$schema": "...", "$ref": "catalog.json#/components/{type}"}
+	ref := "catalog.json#/components/" + compType
+	sch, err := v.compiler.Compile(ref)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: failed to compile schema for component %s: %s", path, compType, err)}
+	}
+
+	inst := toJSONSchemaValue(comp)
+	return formatValidationErrors(sch, inst, path)
+}
+
+// formatValidationErrors runs schema validation and returns formatted error strings.
+func formatValidationErrors(sch *jsonschema.Schema, instance any, basePath string) []string {
+	err := sch.Validate(instance)
+	if err == nil {
+		return nil
+	}
+
+	ve, ok := err.(*jsonschema.ValidationError)
+	if !ok {
+		return []string{fmt.Sprintf("%s: %s", basePath, err.Error())}
+	}
+
+	var results []string
+	collectLeafErrors(ve, basePath, &results, instance)
+	return results
+}
+
+// collectLeafErrors walks the validation error tree and collects leaf error messages.
+func collectLeafErrors(ve *jsonschema.ValidationError, basePath string, results *[]string, instance any) {
+	if len(ve.Causes) == 0 {
+		// Leaf error.
+		pathStr := strings.Join(ve.InstanceLocation, ".")
+		fullPath := basePath
+		if pathStr != "" {
+			fullPath = basePath + "." + pathStr
+		}
+		var msg string
+		if kt, ok := ve.ErrorKind.(*kind.Type); ok {
+			// Resolve the actual instance value for Python-compatible error format.
+			want := strings.Join(kt.Want, " or ")
+			if val := resolveInstanceValue(instance, []string(ve.InstanceLocation)); val != nil {
+				if s, ok := val.(string); ok {
+					msg = fmt.Sprintf("'%s' is not of type '%s'", s, want)
+				} else {
+					msg = fmt.Sprintf("%v is not of type '%s'", val, want)
+				}
+			} else {
+				msg = fmt.Sprintf("%s is not of type '%s'", kt.Got, want)
+			}
+		} else {
+			msg = formatErrorKind(ve.ErrorKind)
+		}
+		// Simplify "unevaluated/additional properties" messages.
+		if (strings.Contains(msg, "unevaluated properties") || strings.Contains(msg, "additional properties")) &&
+			strings.Contains(msg, "(") && strings.Contains(msg, ")") {
+			msg = msg[strings.Index(msg, "(")+1 : strings.LastIndex(msg, ")")]
+		}
+		*results = append(*results, fmt.Sprintf("%s: %s", fullPath, msg))
+		return
+	}
+	for _, cause := range ve.Causes {
+		collectLeafErrors(cause, basePath, results, instance)
+	}
+}
+
+// resolveInstanceValue walks the instance document using a JSON pointer path
+// to find the actual value at that location.
+func resolveInstanceValue(instance any, location []string) any {
+	current := instance
+	for _, token := range location {
+		switch v := current.(type) {
+		case map[string]any:
+			var ok bool
+			current, ok = v[token]
+			if !ok {
+				return nil
+			}
+		default:
+			return nil
+		}
+	}
+	return current
+}
+
+// formatErrorKind produces human-readable error messages from jsonschema error kinds,
+// matching the style used in Python's jsonschema library for conformance compatibility.
+func formatErrorKind(ek jsonschema.ErrorKind) string {
+	switch k := ek.(type) {
+	case *kind.Required:
+		if len(k.Missing) == 1 {
+			return fmt.Sprintf("'%s' is a required property", k.Missing[0])
+		}
+		quoted := make([]string, len(k.Missing))
+		for i, m := range k.Missing {
+			quoted[i] = "'" + m + "'"
+		}
+		return fmt.Sprintf("required properties %s are missing", strings.Join(quoted, ", "))
+	case *kind.Type:
+		want := strings.Join(k.Want, " or ")
+		return fmt.Sprintf("%s is not of type '%s'", k.Got, want)
+	case *kind.Const:
+		return fmt.Sprintf("'%v' was expected", k.Want)
+	case *kind.Enum:
+		return "is not one of the allowed values"
+	case *kind.AdditionalProperties:
+		return fmt.Sprintf("additional properties are not allowed (%s)", strings.Join(k.Properties, ", "))
+	default:
+		return fmt.Sprintf("%v", ek)
+	}
+}
+
+// toJSONSchemaValue re-parses a Go value through jsonschema.UnmarshalJSON
+// so that numbers are represented as json.Number (required by the validator).
+// toAnySlice converts []map[string]any to []any, or returns []any as-is.
+// This handles the Go type system mismatch where the parser constructs
+// []map[string]any but type assertions expect []any.
+func toAnySlice(v any) ([]any, bool) {
+	switch s := v.(type) {
+	case []any:
+		return s, true
+	case []map[string]any:
+		result := make([]any, len(s))
+		for i, m := range s {
+			result[i] = m
+		}
+		return result, true
+	}
+	return nil, false
+}
+
+// toJSONSchemaValue re-parses a Go value through jsonschema.UnmarshalJSON so that
+// numbers are represented as json.Number (required by the schema validator library).
+// When called from the streaming parser (which already uses json.Decoder with
+// UseNumber), the re-serialization is largely a no-op for numeric types. This
+// conversion remains necessary for values originating from external callers that
+// use standard json.Unmarshal (which decodes numbers as float64).
+func toJSONSchemaValue(v any) any {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return v
+	}
+	parsed, err := jsonschema.UnmarshalJSON(strings.NewReader(string(data)))
+	if err != nil {
+		return v
+	}
+	return parsed
+}
+
+func toComponentList(items []any) []map[string]any {
+	var result []map[string]any
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// findRootID finds the root ID from A2UI messages for a given surface.
+func findRootID(messages []map[string]any, surfaceID string) string {
+	for _, message := range messages {
+		if cs, ok := message["createSurface"].(map[string]any); ok {
+			if surfaceID != "" {
+				if sid, _ := cs[SurfaceIDKey].(string); sid != surfaceID {
+					continue
+				}
+			}
+			if r, ok := cs[FieldRoot].(string); ok {
+				return r
+			}
+			return FieldRoot
+		}
+	}
+	return ""
+}
+
+// ValidateComponentIntegrity validates component IDs uniqueness, root existence, and dangling refs.
+func ValidateComponentIntegrity(rootID string, components []map[string]any, refMap RefFieldsMap, skipRootCheck bool) error {
+	ids := make(map[string]struct{})
+
+	// 1. Collect IDs and check for duplicates
+	for _, comp := range components {
+		compID, _ := comp[FieldID].(string)
+		if compID == "" {
+			continue
+		}
+		if _, exists := ids[compID]; exists {
+			return fmt.Errorf("duplicate component ID: %s", compID)
+		}
+		ids[compID] = struct{}{}
+	}
+
+	// 2. Check for root component
+	if !skipRootCheck && rootID != "" {
+		if _, exists := ids[rootID]; !exists {
+			return fmt.Errorf("missing root component: no component has id='%s'", rootID)
+		}
+	}
+
+	// 3. Check for dangling references
+	if rootID != "" && !skipRootCheck {
+		for _, comp := range components {
+			for refID, fieldName := range getComponentReferencesFlat(comp, refMap) {
+				if _, exists := ids[refID]; !exists {
+					compID, _ := comp[FieldID].(string)
+					return fmt.Errorf("component '%s' references non-existent component '%s' in field '%s'",
+						compID, refID, fieldName)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// AnalyzeTopology analyzes the component tree topology and returns reachable IDs.
+func AnalyzeTopology(rootID string, components []map[string]any, refMap RefFieldsMap, raiseOnOrphans bool) (map[string]struct{}, error) {
+	adjList := make(map[string][]string)
+	allIDs := make(map[string]struct{})
+
+	for _, comp := range components {
+		compID, _ := comp[FieldID].(string)
+		if compID == "" {
+			continue
+		}
+		allIDs[compID] = struct{}{}
+		if _, exists := adjList[compID]; !exists {
+			adjList[compID] = nil
+		}
+
+		for refID, fieldName := range getComponentReferencesFlat(comp, refMap) {
+			if refID == compID {
+				return nil, fmt.Errorf("self-reference detected: component '%s' references itself in field '%s'", compID, fieldName)
+			}
+			adjList[compID] = append(adjList[compID], refID)
+		}
+	}
+
+	visited := make(map[string]struct{})
+	recStack := make(map[string]struct{})
+
+	var dfs func(nodeID string, depth int) error
+	dfs = func(nodeID string, depth int) error {
+		if depth > MaxGlobalDepth {
+			return fmt.Errorf("global recursion limit exceeded: logical depth > %d", MaxGlobalDepth)
+		}
+		visited[nodeID] = struct{}{}
+		recStack[nodeID] = struct{}{}
+
+		for _, neighbor := range adjList[nodeID] {
+			if _, seen := visited[neighbor]; !seen {
+				if err := dfs(neighbor, depth+1); err != nil {
+					return err
+				}
+			} else if _, inStack := recStack[neighbor]; inStack {
+				return fmt.Errorf("circular reference detected involving component '%s'", neighbor)
+			}
+		}
+
+		delete(recStack, nodeID)
+		return nil
+	}
+
+	if rootID != "" {
+		if _, exists := allIDs[rootID]; exists {
+			if err := dfs(rootID, 0); err != nil {
+				return nil, err
+			}
+		}
+
+		if raiseOnOrphans {
+			var orphans []string
+			for id := range allIDs {
+				if _, ok := visited[id]; !ok {
+					orphans = append(orphans, id)
+				}
+			}
+			if len(orphans) > 0 {
+				sort.Strings(orphans)
+				return nil, fmt.Errorf("component '%s' is not reachable from '%s'", orphans[0], rootID)
+			}
+		}
+	} else {
+		// No root: traverse everything to check for cycles
+		sortedIDs := make([]string, 0, len(allIDs))
+		for id := range allIDs {
+			sortedIDs = append(sortedIDs, id)
+		}
+		sort.Strings(sortedIDs)
+		for _, nodeID := range sortedIDs {
+			if _, ok := visited[nodeID]; !ok {
+				if err := dfs(nodeID, 0); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return visited, nil
+}
+
+// ExtractComponentRefFields parses the catalog to identify which component properties reference other components.
+func ExtractComponentRefFields(catalog *A2uiCatalog) RefFieldsMap {
+	refMap := make(RefFieldsMap)
+	if catalog == nil {
+		return refMap
+	}
+
+	var allComponents map[string]any
+	if catalog.CatalogSchema != nil {
+		allComponents, _ = catalog.CatalogSchema[FieldComponents].(map[string]any)
+	}
+
+	for compName, compSchema := range allComponents {
+		cs, ok := compSchema.(map[string]any)
+		if !ok {
+			continue
+		}
+		singleRefs := make(map[string]struct{})
+		listRefs := make(map[string]struct{})
+		extractRefFieldsFromProps(cs, singleRefs, listRefs)
+
+		if len(singleRefs) > 0 || len(listRefs) > 0 {
+			refMap[compName] = RefFields{SingleRefs: singleRefs, ListRefs: listRefs}
+		}
+	}
+
+	return refMap
+}
+
+func extractRefFieldsFromProps(cs map[string]any, singleRefs, listRefs map[string]struct{}) {
+	props, _ := cs["properties"].(map[string]any)
+	for propName, propSchema := range props {
+		ps, _ := propSchema.(map[string]any)
+		if ps == nil {
+			continue
+		}
+		if isComponentIDRef(ps) || propName == "child" || propName == "contentChild" || propName == "entryPointChild" {
+			singleRefs[propName] = struct{}{}
+		} else if isChildListRef(ps) || propName == "children" {
+			listRefs[propName] = struct{}{}
+		}
+	}
+
+	for _, key := range []string{"allOf", "oneOf", "anyOf"} {
+		if arr, ok := cs[key].([]any); ok {
+			for _, sub := range arr {
+				if subMap, ok := sub.(map[string]any); ok {
+					extractRefFieldsFromProps(subMap, singleRefs, listRefs)
+				}
+			}
+		}
+	}
+}
+
+func isComponentIDRef(ps map[string]any) bool {
+	if ref, ok := ps["$ref"].(string); ok {
+		if strings.HasSuffix(ref, "ComponentId") || strings.HasSuffix(ref, "child") || strings.Contains(ref, "/child") {
+			return true
+		}
+	}
+	if ps["type"] == "string" && ps["title"] == "ComponentId" {
+		return true
+	}
+	for _, key := range []string{"oneOf", "anyOf", "allOf"} {
+		if arr, ok := ps[key].([]any); ok {
+			for _, sub := range arr {
+				if subMap, ok := sub.(map[string]any); ok && isComponentIDRef(subMap) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func isChildListRef(ps map[string]any) bool {
+	if ref, ok := ps["$ref"].(string); ok {
+		if strings.HasSuffix(ref, "ChildList") || strings.HasSuffix(ref, "children") || strings.Contains(ref, "/children") {
+			return true
+		}
+	}
+	if ps["type"] == "object" {
+		if props, ok := ps["properties"].(map[string]any); ok {
+			if _, ok := props["explicitList"]; ok {
+				return true
+			}
+			if _, ok := props["template"]; ok {
+				return true
+			}
+			if _, ok := props["componentId"]; ok {
+				return true
+			}
+		}
+	}
+	if ps["type"] == "array" {
+		if items, ok := ps["items"].(map[string]any); ok && isComponentIDRef(items) {
+			return true
+		}
+	}
+	for _, key := range []string{"oneOf", "anyOf", "allOf"} {
+		if arr, ok := ps[key].([]any); ok {
+			for _, sub := range arr {
+				if subMap, ok := sub.(map[string]any); ok && isChildListRef(subMap) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// getComponentReferencesFlat returns referenced component IDs mapped to their field names.
+func getComponentReferencesFlat(component map[string]any, refMap RefFieldsMap) map[string]string {
+	result := make(map[string]string)
+
+	compVal := component["component"]
+	switch cv := compVal.(type) {
+	case string:
+		// v0.9 flattened
+		getRefsRecursively(cv, component, refMap, result)
+	case map[string]any:
+		// structured
+		for cType, cProps := range cv {
+			if propsMap, ok := cProps.(map[string]any); ok {
+				getRefsRecursively(cType, propsMap, refMap, result)
+			}
+		}
+	}
+	return result
+}
+
+// Heuristic field sets for reference detection.
+var (
+	heuristicSingle = map[string]struct{}{
+		"child": {}, "contentChild": {}, "entryPointChild": {},
+		"detail": {}, "summary": {}, "root": {},
+	}
+	heuristicList = map[string]struct{}{
+		"children": {}, "explicitList": {}, "template": {},
+	}
+)
+
+func getRefsRecursively(compType string, props map[string]any, refMap RefFieldsMap, result map[string]string) {
+	if compType == "" || props == nil {
+		return
+	}
+
+	rf := refMap[compType]
+
+	for key, value := range props {
+		_, isSingleRef := rf.SingleRefs[key]
+		_, isHeuristicSingle := heuristicSingle[key]
+		_, isListRef := rf.ListRefs[key]
+		_, isHeuristicList := heuristicList[key]
+
+		if isSingleRef || isHeuristicSingle {
+			if s, ok := value.(string); ok {
+				result[s] = key
+			} else if vm, ok := value.(map[string]any); ok {
+				if cid, ok := vm["componentId"].(string); ok {
+					result[cid] = key + ".componentId"
+				}
+			}
+		} else if isListRef || isHeuristicList {
+			switch v := value.(type) {
+			case []any:
+				for _, item := range v {
+					if s, ok := item.(string); ok {
+						result[s] = key
+					}
+				}
+			case map[string]any:
+				if explList, ok := v["explicitList"].([]any); ok {
+					for _, item := range explList {
+						if s, ok := item.(string); ok {
+							result[s] = key + ".explicitList"
+						}
+					}
+				} else if tpl, ok := v["template"].(map[string]any); ok {
+					if cid, ok := tpl["componentId"].(string); ok {
+						result[cid] = key + ".template.componentId"
+					}
+				} else if cid, ok := v["componentId"].(string); ok {
+					result[cid] = key + ".componentId"
+				}
+			}
+		}
+
+		// Handle nested arrays (e.g., tabs)
+		if arr, ok := value.([]any); ok && !isListRef {
+			for i, item := range arr {
+				if itemMap, ok := item.(map[string]any); ok {
+					if childID, ok := itemMap["child"].(string); ok {
+						result[childID] = fmt.Sprintf("%s[%d].child", key, i)
+					}
+				}
+			}
+		}
+	}
+}
+
+// ValidateRecursionAndPaths validates recursion depth limits and path syntax.
+func ValidateRecursionAndPaths(data any) error {
+	return validateRecursionAndPathsRecursive(data, 0, 0)
+}
+
+func validateRecursionAndPathsRecursive(item any, globalDepth, funcDepth int) error {
+	if globalDepth > MaxGlobalDepth {
+		return fmt.Errorf("global recursion limit exceeded: depth > %d", MaxGlobalDepth)
+	}
+
+	switch v := item.(type) {
+	case []any:
+		for _, x := range v {
+			if err := validateRecursionAndPathsRecursive(x, globalDepth+1, funcDepth); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		// Check path
+		if p, ok := v[FieldPath].(string); ok {
+			if !RelaxedPathPattern.MatchString(p) {
+				return fmt.Errorf("invalid path syntax: '%s'", p)
+			}
+		}
+
+		// Check for FunctionCall
+		_, hasCall := v[FieldCall]
+		_, hasArgs := v[FieldArgs]
+		isFunc := hasCall && hasArgs
+
+		if isFunc {
+			if funcDepth >= MaxFuncCallDepth {
+				return fmt.Errorf("recursion limit exceeded: %s depth > %d", FieldFunctionCall, MaxFuncCallDepth)
+			}
+			for k, val := range v {
+				if k == FieldArgs {
+					if err := validateRecursionAndPathsRecursive(val, globalDepth+1, funcDepth+1); err != nil {
+						return err
+					}
+				} else {
+					if err := validateRecursionAndPathsRecursive(val, globalDepth+1, funcDepth); err != nil {
+						return err
+					}
+				}
+			}
+		} else {
+			for _, val := range v {
+				if err := validateRecursionAndPathsRecursive(val, globalDepth+1, funcDepth); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/agent_sdks/go/schema/validator_test.go
+++ b/agent_sdks/go/schema/validator_test.go
@@ -1,0 +1,869 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"strings"
+	"testing"
+)
+
+// newCatalog09 builds a mock v0.9 catalog for testing.
+func newCatalog09() *A2uiCatalog {
+	s2cSchema := map[string]any{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id":     "https://a2ui.org/specification/v0_9/server_to_client.json",
+		"title":   "A2UI Message Schema",
+		"oneOf": []any{
+			map[string]any{"$ref": "#/$defs/CreateSurfaceMessage"},
+			map[string]any{"$ref": "#/$defs/UpdateComponentsMessage"},
+			map[string]any{"$ref": "#/$defs/UpdateDataModelMessage"},
+			map[string]any{"$ref": "#/$defs/DeleteSurfaceMessage"},
+		},
+		"$defs": map[string]any{
+			"CreateSurfaceMessage": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"version": map[string]any{"const": "v0.9"},
+					"createSurface": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"surfaceId": map[string]any{"type": "string"},
+							"catalogId": map[string]any{"type": "string"},
+							"theme":     map[string]any{"type": "object", "additionalProperties": true},
+						},
+						"required":             []any{"surfaceId", "catalogId"},
+						"additionalProperties": false,
+					},
+				},
+				"required":             []any{"version", "createSurface"},
+				"additionalProperties": false,
+			},
+			"UpdateComponentsMessage": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"version": map[string]any{"const": "v0.9"},
+					"updateComponents": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"surfaceId": map[string]any{"type": "string"},
+							"components": map[string]any{
+								"type":     "array",
+								"minItems": 1,
+								"items":    map[string]any{"$ref": "catalog.json#/$defs/anyComponent"},
+							},
+						},
+						"required":             []any{"surfaceId", "components"},
+						"additionalProperties": false,
+					},
+				},
+				"required":             []any{"version", "updateComponents"},
+				"additionalProperties": false,
+			},
+			"UpdateDataModelMessage": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"version": map[string]any{"const": "v0.9"},
+					"updateDataModel": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"surfaceId": map[string]any{"type": "string"},
+							"path":      map[string]any{"type": "string"},
+							"value":     map[string]any{"additionalProperties": true},
+						},
+						"required":             []any{"surfaceId"},
+						"additionalProperties": false,
+					},
+				},
+				"required":             []any{"version", "updateDataModel"},
+				"additionalProperties": false,
+			},
+			"DeleteSurfaceMessage": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"version": map[string]any{"const": "v0.9"},
+					"deleteSurface": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"surfaceId": map[string]any{"type": "string"},
+						},
+						"required":             []any{"surfaceId"},
+						"additionalProperties": false,
+					},
+				},
+				"required":             []any{"deleteSurface", "version"},
+				"additionalProperties": false,
+			},
+		},
+	}
+
+	catalogSchema := map[string]any{
+		"$schema":   "https://json-schema.org/draft/2020-12/schema",
+		"$id":       "https://a2ui.org/specification/v0_9/basic_catalog.json",
+		"title":     "A2UI Basic Catalog",
+		"catalogId": "https://a2ui.dev/specification/v0_9/basic_catalog.json",
+		"components": map[string]any{
+			"Text": map[string]any{
+				"type": "object",
+				"allOf": []any{
+					map[string]any{"$ref": "common_types.json#/$defs/ComponentCommon"},
+					map[string]any{"$ref": "#/$defs/CatalogComponentCommon"},
+				},
+				"properties": map[string]any{
+					"component": map[string]any{"const": "Text"},
+					"text":      map[string]any{"$ref": "common_types.json#/$defs/DynamicString"},
+				},
+				"required":              []any{"component", "text"},
+				"unevaluatedProperties": false,
+			},
+			"Image": map[string]any{
+				"type": "object",
+				"allOf": []any{
+					map[string]any{"$ref": "common_types.json#/$defs/ComponentCommon"},
+					map[string]any{"$ref": "#/$defs/CatalogComponentCommon"},
+				},
+				"properties": map[string]any{
+					"component": map[string]any{"const": "Image"},
+					"url":       map[string]any{"type": "string"},
+				},
+				"required":              []any{"component", "url"},
+				"unevaluatedProperties": false,
+			},
+			"Column": map[string]any{
+				"type": "object",
+				"allOf": []any{
+					map[string]any{"$ref": "common_types.json#/$defs/ComponentCommon"},
+					map[string]any{"$ref": "#/$defs/CatalogComponentCommon"},
+				},
+				"properties": map[string]any{
+					"component": map[string]any{"const": "Column"},
+					"children":  map[string]any{"$ref": "common_types.json#/$defs/ChildList"},
+				},
+				"required":              []any{"component", "children"},
+				"unevaluatedProperties": false,
+			},
+			"Card": map[string]any{
+				"type": "object",
+				"allOf": []any{
+					map[string]any{"$ref": "common_types.json#/$defs/ComponentCommon"},
+					map[string]any{"$ref": "#/$defs/CatalogComponentCommon"},
+				},
+				"properties": map[string]any{
+					"component": map[string]any{"const": "Card"},
+					"child":     map[string]any{"$ref": "common_types.json#/$defs/ComponentId"},
+				},
+				"required":              []any{"component", "child"},
+				"unevaluatedProperties": false,
+			},
+			"Button": map[string]any{
+				"type": "object",
+				"allOf": []any{
+					map[string]any{"$ref": "common_types.json#/$defs/ComponentCommon"},
+					map[string]any{"$ref": "#/$defs/CatalogComponentCommon"},
+				},
+				"properties": map[string]any{
+					"component": map[string]any{"const": "Button"},
+					"text":      map[string]any{"type": "string"},
+					"action":    map[string]any{"$ref": "common_types.json#/$defs/Action"},
+				},
+				"required":              []any{"component", "text", "action"},
+				"unevaluatedProperties": false,
+			},
+		},
+		"$defs": map[string]any{
+			"CatalogComponentCommon": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"weight": map[string]any{"type": "number"}},
+			},
+			"anyComponent": map[string]any{
+				"oneOf": []any{
+					map[string]any{"$ref": "#/components/Text"},
+					map[string]any{"$ref": "#/components/Image"},
+					map[string]any{"$ref": "#/components/Column"},
+					map[string]any{"$ref": "#/components/Card"},
+					map[string]any{"$ref": "#/components/Button"},
+				},
+				"discriminator": map[string]any{"propertyName": "component"},
+			},
+		},
+	}
+
+	commonTypesSchema := map[string]any{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id":     "https://a2ui.org/specification/v0_9/common_types.json",
+		"title":   "A2UI Common Types",
+		"$defs": map[string]any{
+			"ComponentId": map[string]any{"type": "string"},
+			"Action":      map[string]any{"type": "object", "additionalProperties": true},
+			"ComponentCommon": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"id": map[string]any{"$ref": "#/$defs/ComponentId"}},
+				"required":   []any{"id"},
+			},
+			"DataBinding": map[string]any{"type": "object"},
+			"DynamicString": map[string]any{
+				"anyOf": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"$ref": "#/$defs/DataBinding"},
+				},
+			},
+			"DynamicValue": map[string]any{
+				"anyOf": []any{
+					map[string]any{"type": "object"},
+					map[string]any{"type": "array"},
+					map[string]any{"$ref": "#/$defs/DataBinding"},
+				},
+			},
+			"DynamicNumber": map[string]any{
+				"anyOf": []any{
+					map[string]any{"type": "number"},
+					map[string]any{"$ref": "#/$defs/DataBinding"},
+				},
+			},
+			"ChildList": map[string]any{
+				"oneOf": []any{
+					map[string]any{"type": "array", "items": map[string]any{"$ref": "#/$defs/ComponentId"}},
+					map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"componentId": map[string]any{"$ref": "#/$defs/ComponentId"},
+							"path":        map[string]any{"type": "string"},
+						},
+						"required":             []any{"componentId", "path"},
+						"additionalProperties": false,
+					},
+				},
+			},
+		},
+	}
+
+	return &A2uiCatalog{
+		Version:           Version09,
+		Name:              "standard",
+		CatalogSchema:     catalogSchema,
+		S2CSchema:         s2cSchema,
+		CommonTypesSchema: commonTypesSchema,
+	}
+}
+
+// makePayload09 creates a v0.9 test payload with components.
+func makePayload09(components []map[string]any) []any {
+	return []any{
+		map[string]any{
+			"version":       "v0.9",
+			"createSurface": map[string]any{"surfaceId": "test-surface", "catalogId": "std"},
+		},
+		map[string]any{
+			"version": "v0.9",
+			"updateComponents": map[string]any{
+				"surfaceId":  "test-surface",
+				"components": mapsToAnySlice(components),
+			},
+		},
+	}
+}
+
+func mapsToAnySlice(m []map[string]any) []any {
+	s := make([]any, len(m))
+	for i, v := range m {
+		s[i] = v
+	}
+	return s
+}
+
+func TestValidator09CreateSurface(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	message := []any{
+		map[string]any{
+			"version": "v0.9",
+			"createSurface": map[string]any{
+				"surfaceId": "test-id",
+				"catalogId": "standard",
+				"theme":     map[string]any{"primaryColor": "blue"},
+			},
+		},
+	}
+	if err := v.Validate(message, "root", false); err != nil {
+		t.Fatalf("expected valid message, got: %v", err)
+	}
+}
+
+func TestValidator09MissingVersion(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	invalid := []any{
+		map[string]any{
+			"createSurface": map[string]any{"surfaceId": "123", "catalogId": "standard"},
+		},
+	}
+	err := v.Validate(invalid, "root", false)
+	if err == nil {
+		t.Fatal("expected validation error for missing version")
+	}
+	if !strings.Contains(err.Error(), "'version' is a required property") &&
+		!strings.Contains(err.Error(), "version") {
+		t.Errorf("expected version-related error, got: %v", err)
+	}
+}
+
+func TestValidator09WrongVersion(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	invalid := []any{
+		map[string]any{
+			"version":       "0.8",
+			"createSurface": map[string]any{"surfaceId": "123", "catalogId": "standard"},
+		},
+	}
+	err := v.Validate(invalid, "root", false)
+	if err == nil {
+		t.Fatal("expected validation error for wrong version")
+	}
+	if !strings.Contains(err.Error(), "v0.9") {
+		t.Errorf("expected v0.9-related error, got: %v", err)
+	}
+}
+
+func TestValidator09SurfaceIdMustBeString(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	invalid := []any{
+		map[string]any{
+			"version":       "v0.9",
+			"createSurface": map[string]any{"surfaceId": 123, "catalogId": "standard"},
+		},
+	}
+	err := v.Validate(invalid, "root", false)
+	if err == nil {
+		t.Fatal("expected validation error for non-string surfaceId")
+	}
+	if !strings.Contains(err.Error(), "string") {
+		t.Errorf("expected string type error, got: %v", err)
+	}
+}
+
+func TestValidator09MissingCatalogId(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	invalid := []any{
+		map[string]any{
+			"version":       "v0.9",
+			"createSurface": map[string]any{"surfaceId": "123"},
+		},
+	}
+	err := v.Validate(invalid, "root", false)
+	if err == nil {
+		t.Fatal("expected validation error for missing catalogId")
+	}
+	if !strings.Contains(err.Error(), "catalogId") {
+		t.Errorf("expected catalogId-related error, got: %v", err)
+	}
+}
+
+func TestValidator09UnknownMessageType(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	invalid := []any{
+		map[string]any{"unknownMessage": map[string]any{}},
+	}
+	err := v.Validate(invalid, "root", false)
+	if err == nil {
+		t.Fatal("expected validation error for unknown message type")
+	}
+	if !strings.Contains(err.Error(), "Unknown message type") {
+		t.Errorf("expected 'Unknown message type' error, got: %v", err)
+	}
+}
+
+func TestValidateDuplicateIDs(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	components := []map[string]any{
+		{"id": "root", "component": "Text", "text": "Root"},
+		{"id": "c1", "component": "Text", "text": "Hello"},
+		{"id": "c1", "component": "Text", "text": "World"},
+	}
+	payload := makePayload09(components)
+	err := v.Validate(payload, "root", true)
+	if err == nil {
+		t.Fatal("expected error for duplicate IDs")
+	}
+	if !strings.Contains(err.Error(), "duplicate component ID") {
+		t.Errorf("expected duplicate ID error, got: %v", err)
+	}
+}
+
+func TestValidateMissingRoot(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	payload := []any{
+		map[string]any{
+			"version":       "v0.9",
+			"createSurface": map[string]any{"surfaceId": "test", "catalogId": "std"},
+		},
+		map[string]any{
+			"version": "v0.9",
+			"updateComponents": map[string]any{
+				"surfaceId": "test",
+				"components": []any{
+					map[string]any{"id": "c1", "component": "Text", "text": "hi"},
+				},
+			},
+		},
+	}
+	err := v.Validate(payload, "root", true)
+	if err == nil {
+		t.Fatal("expected error for missing root component")
+	}
+	if !strings.Contains(err.Error(), "missing root component") {
+		t.Errorf("expected missing root error, got: %v", err)
+	}
+}
+
+func TestValidateDanglingChildrenRef(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	components := []map[string]any{
+		{"id": "root", "component": "Column", "children": []any{"missing"}},
+	}
+	payload := makePayload09(components)
+	err := v.Validate(payload, "root", true)
+	if err == nil {
+		t.Fatal("expected error for dangling reference")
+	}
+	if !strings.Contains(err.Error(), "references non-existent component") {
+		t.Errorf("expected dangling ref error, got: %v", err)
+	}
+}
+
+func TestValidateDanglingChildRef(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	components := []map[string]any{
+		{"id": "root", "component": "Card", "child": "missing"},
+	}
+	payload := makePayload09(components)
+	err := v.Validate(payload, "root", true)
+	if err == nil {
+		t.Fatal("expected error for dangling child reference")
+	}
+	if !strings.Contains(err.Error(), "references non-existent component") {
+		t.Errorf("expected dangling ref error, got: %v", err)
+	}
+}
+
+func TestFindRootIDV09(t *testing.T) {
+	// createSurface with explicit root
+	messages := []map[string]any{
+		{"createSurface": map[string]any{"surfaceId": "s1", "root": "custom-root"}},
+		{"updateComponents": map[string]any{"surfaceId": "s1", "components": []any{}}},
+	}
+	rootID := findRootID(messages, "")
+	if rootID != "custom-root" {
+		t.Errorf("expected custom-root, got %q", rootID)
+	}
+
+	// createSurface without explicit root defaults to "root"
+	messages = []map[string]any{
+		{"createSurface": map[string]any{"surfaceId": "s1"}},
+		{"updateComponents": map[string]any{"surfaceId": "s1", "components": []any{}}},
+	}
+	rootID = findRootID(messages, "")
+	if rootID != "root" {
+		t.Errorf("expected 'root', got %q", rootID)
+	}
+
+	// Incremental update without createSurface returns empty
+	messages = []map[string]any{
+		{"updateComponents": map[string]any{"surfaceId": "s1", "components": []any{}}},
+	}
+	rootID = findRootID(messages, "")
+	if rootID != "" {
+		t.Errorf("expected empty string, got %q", rootID)
+	}
+}
+
+func TestAnalyzeTopologyCircular(t *testing.T) {
+	refMap := RefFieldsMap{
+		"Node": {SingleRefs: map[string]struct{}{"next": {}}, ListRefs: map[string]struct{}{}},
+	}
+	components := []map[string]any{
+		{"id": "c1", "component": "Node", "next": "c2"},
+		{"id": "c2", "component": "Node", "next": "c1"},
+	}
+	_, err := AnalyzeTopology("c1", components, refMap, true)
+	if err == nil {
+		t.Fatal("expected circular reference error")
+	}
+	if !strings.Contains(err.Error(), "circular reference") {
+		t.Errorf("expected circular reference error, got: %v", err)
+	}
+}
+
+func TestAnalyzeTopologySelfRef(t *testing.T) {
+	refMap := RefFieldsMap{
+		"Node": {SingleRefs: map[string]struct{}{"next": {}}, ListRefs: map[string]struct{}{}},
+	}
+	components := []map[string]any{
+		{"id": "c1", "component": "Node", "next": "c1"},
+	}
+	_, err := AnalyzeTopology("c1", components, refMap, true)
+	if err == nil {
+		t.Fatal("expected self-reference error")
+	}
+	if !strings.Contains(err.Error(), "self-reference") {
+		t.Errorf("expected self-reference error, got: %v", err)
+	}
+}
+
+func TestAnalyzeTopologyReachable(t *testing.T) {
+	refMap := RefFieldsMap{
+		"Node": {SingleRefs: map[string]struct{}{"next": {}}, ListRefs: map[string]struct{}{}},
+	}
+	components := []map[string]any{
+		{"id": "root", "component": "Node", "next": "c1"},
+		{"id": "c1", "component": "Node", "next": "c2"},
+		{"id": "c2", "component": "Node"},
+		{"id": "orphan", "component": "Node"},
+	}
+	reachable, err := AnalyzeTopology("root", components, refMap, false)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	for _, expected := range []string{"root", "c1", "c2"} {
+		if _, ok := reachable[expected]; !ok {
+			t.Errorf("expected %q to be reachable", expected)
+		}
+	}
+	if _, ok := reachable["orphan"]; ok {
+		t.Error("orphan should not be reachable")
+	}
+}
+
+func TestAnalyzeTopologyOrphansRaise(t *testing.T) {
+	refMap := RefFieldsMap{
+		"Node": {SingleRefs: map[string]struct{}{"next": {}}, ListRefs: map[string]struct{}{}},
+	}
+	components := []map[string]any{
+		{"id": "root", "component": "Node", "next": "c1"},
+		{"id": "c1", "component": "Node"},
+		{"id": "orphan", "component": "Node"},
+	}
+	_, err := AnalyzeTopology("root", components, refMap, true)
+	if err == nil {
+		t.Fatal("expected orphan error")
+	}
+	if !strings.Contains(err.Error(), "not reachable") {
+		t.Errorf("expected 'not reachable' error, got: %v", err)
+	}
+}
+
+func TestExtractComponentRefFieldsMock(t *testing.T) {
+	catalog := &A2uiCatalog{
+		Version: Version09,
+		CatalogSchema: map[string]any{
+			"components": map[string]any{
+				"Container": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"child":    map[string]any{"$ref": "common_types.json#/$defs/ComponentId"},
+						"children": map[string]any{"$ref": "common_types.json#/$defs/ChildList"},
+						"text":     map[string]any{"type": "string"},
+					},
+				},
+				"Text": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"text": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+
+	refMap := ExtractComponentRefFields(catalog)
+
+	// Container should have child as single ref and children as list ref
+	containerRefs, ok := refMap["Container"]
+	if !ok {
+		t.Fatal("expected Container in refMap")
+	}
+	if _, ok := containerRefs.SingleRefs["child"]; !ok {
+		t.Error("expected 'child' in Container.SingleRefs")
+	}
+	if _, ok := containerRefs.ListRefs["children"]; !ok {
+		t.Error("expected 'children' in Container.ListRefs")
+	}
+}
+
+func TestGetComponentReferencesFlat(t *testing.T) {
+	refMap := RefFieldsMap{
+		"Container": {
+			SingleRefs: map[string]struct{}{"child": {}},
+			ListRefs:   map[string]struct{}{"children": {}},
+		},
+	}
+	comp := map[string]any{
+		"id":        "c1",
+		"component": "Container",
+		"child":     "c2",
+		"children":  []any{"c3", "c4"},
+	}
+	refs := getComponentReferencesFlat(comp, refMap)
+
+	if refs["c2"] != "child" {
+		t.Errorf("expected c2 -> child, got %v", refs["c2"])
+	}
+	if refs["c3"] != "children" {
+		t.Errorf("expected c3 -> children, got %v", refs["c3"])
+	}
+	if refs["c4"] != "children" {
+		t.Errorf("expected c4 -> children, got %v", refs["c4"])
+	}
+}
+
+func TestValidateRecursionAndPathsValid(t *testing.T) {
+	data := map[string]any{
+		"path": "/valid/path",
+		"nested": map[string]any{
+			"path": "relative/path",
+		},
+	}
+	if err := ValidateRecursionAndPaths(data); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateRecursionAndPathsInvalid(t *testing.T) {
+	data := map[string]any{
+		"path": "invalid//~3path",
+	}
+	err := ValidateRecursionAndPaths(data)
+	if err == nil {
+		t.Fatal("expected error for invalid path syntax")
+	}
+	if !strings.Contains(err.Error(), "invalid path syntax") {
+		t.Errorf("expected 'invalid path syntax' error, got: %v", err)
+	}
+}
+
+func TestValidateRecursionAndPathsFuncCallDepth(t *testing.T) {
+	// Create deeply nested function calls exceeding MaxFuncCallDepth
+	innermost := map[string]any{
+		"call": "f5",
+		"args": map[string]any{"value": "end"},
+	}
+	current := innermost
+	for i := 4; i >= 0; i-- {
+		current = map[string]any{
+			"call": "f",
+			"args": current,
+		}
+	}
+	err := ValidateRecursionAndPaths(current)
+	if err == nil {
+		t.Fatal("expected recursion limit error")
+	}
+	if !strings.Contains(err.Error(), "recursion limit exceeded") {
+		t.Errorf("expected recursion limit error, got: %v", err)
+	}
+}
+
+func TestValidateComponentIntegrityValid(t *testing.T) {
+	refMap := RefFieldsMap{
+		"Column": {SingleRefs: map[string]struct{}{}, ListRefs: map[string]struct{}{"children": {}}},
+		"Text":   {},
+	}
+	components := []map[string]any{
+		{"id": "root", "component": "Column", "children": []any{"c1"}},
+		{"id": "c1", "component": "Text", "text": "Hello"},
+	}
+	err := ValidateComponentIntegrity("root", components, refMap, false)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidator09UpdateComponents(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	// Valid updateComponents message
+	payload := []any{
+		map[string]any{
+			"version":       "v0.9",
+			"createSurface": map[string]any{"surfaceId": "s1", "catalogId": "std"},
+		},
+		map[string]any{
+			"version": "v0.9",
+			"updateComponents": map[string]any{
+				"surfaceId": "s1",
+				"components": []any{
+					map[string]any{"id": "root", "component": "Text", "text": "Hello"},
+				},
+			},
+		},
+	}
+	if err := v.Validate(payload, "root", true); err != nil {
+		t.Fatalf("expected valid payload, got: %v", err)
+	}
+}
+
+func TestValidator09UpdateDataModel(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	payload := []any{
+		map[string]any{
+			"version": "v0.9",
+			"updateDataModel": map[string]any{
+				"surfaceId": "s1",
+				"value":     map[string]any{"key": "val"},
+			},
+		},
+	}
+	if err := v.Validate(payload, "", false); err != nil {
+		t.Fatalf("expected valid payload, got: %v", err)
+	}
+}
+
+func TestValidator09DeleteSurface(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	payload := []any{
+		map[string]any{
+			"version":       "v0.9",
+			"deleteSurface": map[string]any{"surfaceId": "s1"},
+		},
+	}
+	if err := v.Validate(payload, "", false); err != nil {
+		t.Fatalf("expected valid payload, got: %v", err)
+	}
+}
+
+func TestValidator09DeleteSurfaceMissingSurfaceId(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	payload := []any{
+		map[string]any{
+			"version":       "v0.9",
+			"deleteSurface": map[string]any{},
+		},
+	}
+	err := v.Validate(payload, "", false)
+	if err == nil {
+		t.Fatal("expected validation error for missing surfaceId")
+	}
+	if !strings.Contains(err.Error(), "surfaceId") {
+		t.Errorf("expected surfaceId-related error, got: %v", err)
+	}
+}
+
+func TestValidatorNilCatalog(t *testing.T) {
+	v := NewA2uiValidator(nil)
+	// With nil catalog, fallback path runs (no schema validation, only integrity)
+	payload := map[string]any{"foo": "bar"}
+	// Should not panic
+	_ = v.Validate(payload, "", false)
+}
+
+func TestPrettyErrorMessages(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	payload := []any{
+		map[string]any{
+			"version": "v0.9",
+			"createSurface": map[string]any{
+				"surfaceId": "recipe-card",
+				"catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json",
+			},
+		},
+		map[string]any{
+			"version": "v0.9",
+			"updateComponents": map[string]any{
+				"surfaceId": "recipe-card",
+				"components": []any{
+					map[string]any{
+						"id": "main-column", "component": "Column",
+						"children": []any{"recipe-image"},
+						"gap":      "small",
+					},
+					map[string]any{
+						"id": "recipe-image", "component": "Image",
+						"url":     map[string]any{"path": "/image"},
+						"altText": map[string]any{"path": "/title"},
+						"fit":     "cover",
+					},
+				},
+			},
+		},
+		map[string]any{"unknownMessage": map[string]any{}},
+	}
+
+	err := v.Validate(payload, "root", true)
+	if err == nil {
+		t.Fatal("expected validation errors")
+	}
+
+	errText := err.Error()
+	// Check that we get meaningful error messages
+	if !strings.Contains(errText, "Unknown message type") {
+		t.Errorf("expected 'Unknown message type' in error, got: %v", errText)
+	}
+}
+
+func TestValidateSingleMessage(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	// Single message (not wrapped in array)
+	message := map[string]any{
+		"version": "v0.9",
+		"createSurface": map[string]any{
+			"surfaceId": "test-id",
+			"catalogId": "standard",
+		},
+	}
+	if err := v.Validate(message, "root", false); err != nil {
+		t.Fatalf("expected valid single message, got: %v", err)
+	}
+}
+
+func TestValidateInvalidType(t *testing.T) {
+	catalog := newCatalog09()
+	v := NewA2uiValidator(catalog)
+
+	err := v.Validate("not a valid type", "root", false)
+	if err == nil {
+		t.Fatal("expected error for invalid type")
+	}
+	if !strings.Contains(err.Error(), "must be a dict or list") {
+		t.Errorf("expected type error, got: %v", err)
+	}
+}

--- a/samples/go/catalog_schemas/0.9/rizzcharts_catalog_definition.json
+++ b/samples/go/catalog_schemas/0.9/rizzcharts_catalog_definition.json
@@ -1,0 +1,1066 @@
+{
+  "catalogId": "https://github.com/google/A2UI/blob/main/samples/agent/adk/rizzcharts/rizzcharts_catalog_definition.json",
+  "components": {
+    "Text": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Text"
+            },
+            "text": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text content to display. While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation."
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for the base text style.",
+              "enum": ["h1", "h2", "h3", "h4", "h5", "caption", "body"],
+              "default": "body"
+            }
+          },
+          "required": ["component", "text"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Image": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Image"
+            },
+            "url": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The URL of the image to display."
+            },
+            "fit": {
+              "type": "string",
+              "description": "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property.",
+              "enum": ["contain", "cover", "fill", "none", "scaleDown"],
+              "default": "fill"
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for the image size and style.",
+              "enum": ["icon", "avatar", "smallFeature", "mediumFeature", "largeFeature", "header"],
+              "default": "mediumFeature"
+            }
+          },
+          "required": ["component", "url"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Icon": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Icon"
+            },
+            "name": {
+              "description": "The name of the icon to display.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "accountCircle",
+                    "add",
+                    "arrowBack",
+                    "arrowForward",
+                    "attachFile",
+                    "calendarToday",
+                    "call",
+                    "camera",
+                    "check",
+                    "close",
+                    "delete",
+                    "download",
+                    "edit",
+                    "event",
+                    "error",
+                    "fastForward",
+                    "favorite",
+                    "favoriteOff",
+                    "folder",
+                    "help",
+                    "home",
+                    "info",
+                    "locationOn",
+                    "lock",
+                    "lockOpen",
+                    "mail",
+                    "menu",
+                    "moreVert",
+                    "moreHoriz",
+                    "notificationsOff",
+                    "notifications",
+                    "pause",
+                    "payment",
+                    "person",
+                    "phone",
+                    "photo",
+                    "play",
+                    "print",
+                    "refresh",
+                    "rewind",
+                    "search",
+                    "send",
+                    "settings",
+                    "share",
+                    "shoppingCart",
+                    "skipNext",
+                    "skipPrevious",
+                    "star",
+                    "starHalf",
+                    "starOff",
+                    "stop",
+                    "upload",
+                    "visibility",
+                    "visibilityOff",
+                    "volumeDown",
+                    "volumeMute",
+                    "volumeOff",
+                    "volumeUp",
+                    "warning"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["path"],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": ["component", "name"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Video": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Video"
+            },
+            "url": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The URL of the video to display."
+            }
+          },
+          "required": ["component", "url"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "AudioPlayer": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "AudioPlayer"
+            },
+            "url": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The URL of the audio to be played."
+            },
+            "description": {
+              "description": "A description of the audio, such as a title or summary.",
+              "$ref": "common_types.json#/$defs/DynamicString"
+            }
+          },
+          "required": ["component", "url"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Row": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "description": "A layout component that arranges its children horizontally. To create a grid layout, nest Columns within this Row.",
+          "properties": {
+            "component": {
+              "const": "Row"
+            },
+            "children": {
+              "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+              "$ref": "common_types.json#/$defs/ChildList"
+            },
+            "justify": {
+              "type": "string",
+              "description": "Defines the arrangement of children along the main axis (horizontally). Use 'spaceBetween' to push items to the edges, or 'start'/'end'/'center' to pack them together.",
+              "enum": [
+                "center",
+                "end",
+                "spaceAround",
+                "spaceBetween",
+                "spaceEvenly",
+                "start",
+                "stretch"
+              ],
+              "default": "start"
+            },
+            "align": {
+              "type": "string",
+              "description": "Defines the alignment of children along the cross axis (vertically). This is similar to the CSS 'align-items' property, but uses camelCase values (e.g., 'start').",
+              "enum": ["start", "center", "end", "stretch"],
+              "default": "stretch"
+            }
+          },
+          "required": ["component", "children"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Column": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "description": "A layout component that arranges its children vertically. To create a grid layout, nest Rows within this Column.",
+          "properties": {
+            "component": {
+              "const": "Column"
+            },
+            "children": {
+              "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+              "$ref": "common_types.json#/$defs/ChildList"
+            },
+            "justify": {
+              "type": "string",
+              "description": "Defines the arrangement of children along the main axis (vertically). Use 'spaceBetween' to push items to the edges (e.g. header at top, footer at bottom), or 'start'/'end'/'center' to pack them together.",
+              "enum": [
+                "start",
+                "center",
+                "end",
+                "spaceBetween",
+                "spaceAround",
+                "spaceEvenly",
+                "stretch"
+              ],
+              "default": "start"
+            },
+            "align": {
+              "type": "string",
+              "description": "Defines the alignment of children along the cross axis (horizontally). This is similar to the CSS 'align-items' property.",
+              "enum": ["center", "end", "start", "stretch"],
+              "default": "stretch"
+            }
+          },
+          "required": ["component", "children"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "List": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "List"
+            },
+            "children": {
+              "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list.",
+              "$ref": "common_types.json#/$defs/ChildList"
+            },
+            "direction": {
+              "type": "string",
+              "description": "The direction in which the list items are laid out.",
+              "enum": ["vertical", "horizontal"],
+              "default": "vertical"
+            },
+            "align": {
+              "type": "string",
+              "description": "Defines the alignment of children along the cross axis.",
+              "enum": ["start", "center", "end", "stretch"],
+              "default": "stretch"
+            }
+          },
+          "required": ["component", "children"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Card": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Card"
+            },
+            "child": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the single child component to be rendered inside the card. To display multiple elements, you MUST wrap them in a layout component (like Column or Row) and pass that container's ID here. Do NOT pass multiple IDs or a non-existent ID. Do NOT define the child component inline."
+            }
+          },
+          "required": ["component", "child"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Tabs": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Tabs"
+            },
+            "tabs": {
+              "type": "array",
+              "description": "An array of objects, where each object defines a tab with a title and a child component.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "description": "The tab title.",
+                    "$ref": "common_types.json#/$defs/DynamicString"
+                  },
+                  "child": {
+                    "$ref": "common_types.json#/$defs/ComponentId",
+                    "description": "The ID of the child component. Do NOT define the component inline."
+                  }
+                },
+                "required": ["title", "child"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["component", "tabs"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Modal": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Modal"
+            },
+            "trigger": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the component that opens the modal when interacted with (e.g., a button). Do NOT define the component inline."
+            },
+            "content": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the component to be displayed inside the modal. Do NOT define the component inline."
+            }
+          },
+          "required": ["component", "trigger", "content"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Divider": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Divider"
+            },
+            "axis": {
+              "type": "string",
+              "description": "The orientation of the divider.",
+              "enum": ["horizontal", "vertical"],
+              "default": "horizontal"
+            }
+          },
+          "required": ["component"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Button": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Button"
+            },
+            "child": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the child component. Use a 'Text' component for a labeled button. Only use an 'Icon' if the requirements explicitly ask for an icon-only button. Do NOT define the child component inline."
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for the button style. If omitted, a default button style is used. 'primary' indicates this is the main call-to-action button. 'borderless' means the button has no visual border or background, making its child content appear like a clickable link.",
+              "enum": ["default", "primary", "borderless"],
+              "default": "default"
+            },
+            "action": {
+              "$ref": "common_types.json#/$defs/Action"
+            }
+          },
+          "required": ["component", "child", "action"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "TextField": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "TextField"
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text label for the input field."
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The value of the text field."
+            },
+            "variant": {
+              "type": "string",
+              "description": "The type of input field to display.",
+              "enum": ["longText", "number", "shortText", "obscured"],
+              "default": "shortText"
+            },
+            "validationRegexp": {
+              "type": "string",
+              "description": "A regular expression used for client-side validation of the input."
+            }
+          },
+          "required": ["component", "label"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "CheckBox": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "CheckBox"
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text to display next to the checkbox."
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "The current state of the checkbox (true for checked, false for unchecked)."
+            }
+          },
+          "required": ["component", "label", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "ChoicePicker": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "description": "A component that allows selecting one or more options from a list.",
+          "properties": {
+            "component": {
+              "const": "ChoicePicker"
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The label for the group of options."
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for how the choice picker should be displayed and behave.",
+              "enum": ["multipleSelection", "mutuallyExclusive"],
+              "default": "mutuallyExclusive"
+            },
+            "options": {
+              "type": "array",
+              "description": "The list of available options to choose from.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "description": "The text to display for this option.",
+                    "$ref": "common_types.json#/$defs/DynamicString"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The stable value associated with this option."
+                  }
+                },
+                "required": ["label", "value"],
+                "additionalProperties": false
+              }
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicStringList",
+              "description": "The list of currently selected values. This should be bound to a string array in the data model."
+            },
+            "displayStyle": {
+              "type": "string",
+              "description": "The display style of the component.",
+              "enum": ["checkbox", "chips"],
+              "default": "checkbox"
+            },
+            "filterable": {
+              "type": "boolean",
+              "description": "If true, displays a search input to filter the options.",
+              "default": false
+            }
+          },
+          "required": ["component", "options", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Slider": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Slider"
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The label for the slider."
+            },
+            "min": {
+              "type": "number",
+              "description": "The minimum value of the slider.",
+              "default": 0
+            },
+            "max": {
+              "type": "number",
+              "description": "The maximum value of the slider."
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The current value of the slider."
+            }
+          },
+          "required": ["component", "value", "max"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "DateTimeInput": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "DateTimeInput"
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The selected date and/or time value in ISO 8601 format. If not yet set, initialize with an empty string."
+            },
+            "enableDate": {
+              "type": "boolean",
+              "description": "If true, allows the user to select a date.",
+              "default": false
+            },
+            "enableTime": {
+              "type": "boolean",
+              "description": "If true, allows the user to select a time.",
+              "default": false
+            },
+            "min": {
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "oneOf": [
+                      {
+                        "format": "date"
+                      },
+                      {
+                        "format": "time"
+                      },
+                      {
+                        "format": "date-time"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "description": "The minimum allowed date/time in ISO 8601 format."
+            },
+            "max": {
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "oneOf": [
+                      {
+                        "format": "date"
+                      },
+                      {
+                        "format": "time"
+                      },
+                      {
+                        "format": "date-time"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "description": "The maximum allowed date/time in ISO 8601 format."
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text label for the input field."
+            }
+          },
+          "required": ["component", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Canvas": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "description": "Renders the UI element in a stateful panel next to the chat window.",
+          "properties": {
+            "component": {
+              "const": "Canvas"
+            },
+            "children": {
+              "$ref": "common_types.json#/$defs/ChildList",
+              "description": "Defines the children of the canvas."
+            }
+          },
+          "required": ["component", "children"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Chart": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "description": "An interactive chart that uses a hierarchical list of objects for its data.",
+          "properties": {
+            "component": {
+              "const": "Chart"
+            },
+            "type": {
+              "type": "string",
+              "description": "The type of chart to render.",
+              "enum": ["doughnut", "pie"]
+            },
+            "title": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The title of the chart."
+            },
+            "chartData": {
+              "description": "The data for the chart, provided as a list of items. Can be a literal array or a data model path.",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/ChartItem"
+                  }
+                },
+                {
+                  "$ref": "common_types.json#/$defs/DataBinding"
+                }
+              ]
+            }
+          },
+          "required": ["component", "type", "chartData"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "GoogleMap": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "description": "A component to display a Google Map with pins.",
+          "properties": {
+            "component": {
+              "const": "GoogleMap"
+            },
+            "center": {
+              "$ref": "#/$defs/DynamicLatLng",
+              "description": "The center point of the map, containing latitude and longitude."
+            },
+            "zoom": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The zoom level of the map."
+            },
+            "pins": {
+              "description": "A list of pin objects to display on the map. Can be a literal array or a data model path.",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/MapPin"
+                  }
+                },
+                {
+                  "$ref": "common_types.json#/$defs/DataBinding"
+                }
+              ]
+            }
+          },
+          "required": ["component", "center", "zoom"]
+        }
+      ],
+      "unevaluatedProperties": false
+    }
+  },
+  "$defs": {
+    "CatalogComponentCommon": {
+      "type": "object",
+      "properties": {
+        "weight": {
+          "$ref": "common_types.json#/$defs/DynamicNumber"
+        }
+      }
+    },
+    "ChartItem": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "value": {
+          "type": "number"
+        },
+        "drillDown": {
+          "type": "array",
+          "description": "An optional list of items for the next level of data.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              }
+            },
+            "required": ["label", "value"]
+          }
+        }
+      },
+      "required": ["label", "value"]
+    },
+    "DynamicLatLng": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "lat": {
+              "type": "number"
+            },
+            "lng": {
+              "type": "number"
+            }
+          },
+          "required": ["lat", "lng"],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "common_types.json#/$defs/DataBinding"
+        }
+      ]
+    },
+    "MapPin": {
+      "type": "object",
+      "properties": {
+        "lat": {
+          "type": "number"
+        },
+        "lng": {
+          "type": "number"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "background": {
+          "type": "string",
+          "description": "Hex color code for the pin background (e.g., '#FBBC04')."
+        },
+        "borderColor": {
+          "type": "string",
+          "description": "Hex color code for the pin border (e.g., '#000000')."
+        },
+        "glyphColor": {
+          "type": "string",
+          "description": "Hex color code for the pin's glyph/icon (e.g., '#000000')."
+        }
+      },
+      "required": ["lat", "lng", "name"],
+      "additionalProperties": false
+    },
+    "anyComponent": {
+      "oneOf": [
+        {
+          "$ref": "#/components/AudioPlayer"
+        },
+        {
+          "$ref": "#/components/Button"
+        },
+        {
+          "$ref": "#/components/Canvas"
+        },
+        {
+          "$ref": "#/components/Card"
+        },
+        {
+          "$ref": "#/components/Chart"
+        },
+        {
+          "$ref": "#/components/CheckBox"
+        },
+        {
+          "$ref": "#/components/ChoicePicker"
+        },
+        {
+          "$ref": "#/components/Column"
+        },
+        {
+          "$ref": "#/components/DateTimeInput"
+        },
+        {
+          "$ref": "#/components/Divider"
+        },
+        {
+          "$ref": "#/components/GoogleMap"
+        },
+        {
+          "$ref": "#/components/Icon"
+        },
+        {
+          "$ref": "#/components/Image"
+        },
+        {
+          "$ref": "#/components/List"
+        },
+        {
+          "$ref": "#/components/Modal"
+        },
+        {
+          "$ref": "#/components/Row"
+        },
+        {
+          "$ref": "#/components/Slider"
+        },
+        {
+          "$ref": "#/components/Tabs"
+        },
+        {
+          "$ref": "#/components/Text"
+        },
+        {
+          "$ref": "#/components/TextField"
+        },
+        {
+          "$ref": "#/components/Video"
+        }
+      ]
+    },
+    "anyFunction": {
+      "enum": ["none"]
+    }
+  }
+}

--- a/samples/go/examples/rizzcharts_catalog/0.9/chart.json
+++ b/samples/go/examples/rizzcharts_catalog/0.9/chart.json
@@ -1,0 +1,83 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "sales-dashboard",
+      "catalogId": "https://github.com/google/A2UI/blob/main/samples/agent/adk/rizzcharts/rizzcharts_catalog_definition.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "sales-dashboard",
+      "components": [
+        {
+          "id": "root",
+          "component": "Canvas",
+          "children": ["chart-container"]
+        },
+        {
+          "id": "chart-container",
+          "component": "Column",
+          "children": ["sales-chart"],
+          "align": "center"
+        },
+        {
+          "id": "sales-chart",
+          "component": "Chart",
+          "type": "doughnut",
+          "title": {
+            "path": "/chart.title"
+          },
+          "chartData": {
+            "path": "/chart.items"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "sales-dashboard",
+      "path": "/",
+      "value": {
+        "chart.title": "Sales by Category",
+        "chart.items[0].label": "Apparel",
+        "chart.items[0].value": 41,
+        "chart.items[0].drillDown[0].label": "Tops",
+        "chart.items[0].drillDown[0].value": 31,
+        "chart.items[0].drillDown[1].label": "Bottoms",
+        "chart.items[0].drillDown[1].value": 38,
+        "chart.items[0].drillDown[2].label": "Outerwear",
+        "chart.items[0].drillDown[2].value": 20,
+        "chart.items[0].drillDown[3].label": "Footwear",
+        "chart.items[0].drillDown[3].value": 11,
+        "chart.items[1].label": "Home Goods",
+        "chart.items[1].value": 15,
+        "chart.items[1].drillDown[0].label": "Pillow",
+        "chart.items[1].drillDown[0].value": 8,
+        "chart.items[1].drillDown[1].label": "Coffee Maker",
+        "chart.items[1].drillDown[1].value": 16,
+        "chart.items[1].drillDown[2].label": "Area Rug",
+        "chart.items[1].drillDown[2].value": 3,
+        "chart.items[1].drillDown[3].label": "Bath Towels",
+        "chart.items[1].drillDown[3].value": 14,
+        "chart.items[2].label": "Electronics",
+        "chart.items[2].value": 28,
+        "chart.items[2].drillDown[0].label": "Phones",
+        "chart.items[2].drillDown[0].value": 25,
+        "chart.items[2].drillDown[1].label": "Laptops",
+        "chart.items[2].drillDown[1].value": 27,
+        "chart.items[2].drillDown[2].label": "TVs",
+        "chart.items[2].drillDown[2].value": 21,
+        "chart.items[2].drillDown[3].label": "Other",
+        "chart.items[2].drillDown[3].value": 27,
+        "chart.items[3].label": "Health & Beauty",
+        "chart.items[3].value": 10,
+        "chart.items[4].label": "Other",
+        "chart.items[4].value": 6
+      }
+    }
+  }
+]

--- a/samples/go/examples/rizzcharts_catalog/0.9/map.json
+++ b/samples/go/examples/rizzcharts_catalog/0.9/map.json
@@ -1,0 +1,81 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "la-map-view",
+      "catalogId": "https://github.com/google/A2UI/blob/main/samples/agent/adk/rizzcharts/rizzcharts_catalog_definition.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "la-map-view",
+      "components": [
+        {
+          "id": "root",
+          "component": "Canvas",
+          "children": ["map-layout-container"]
+        },
+        {
+          "id": "map-layout-container",
+          "component": "Column",
+          "children": ["map-header", "location-map"],
+          "align": "stretch"
+        },
+        {
+          "id": "map-header",
+          "component": "Text",
+          "text": "Points of Interest in Los Angeles",
+          "variant": "h2"
+        },
+        {
+          "id": "location-map",
+          "component": "GoogleMap",
+          "center": {
+            "path": "/mapConfig.center"
+          },
+          "zoom": {
+            "path": "/mapConfig.zoom"
+          },
+          "pins": {
+            "path": "/mapConfig.locations"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "la-map-view",
+      "path": "/",
+      "value": {
+        "mapConfig.center.lat": 34.0522,
+        "mapConfig.center.lng": -118.2437,
+        "mapConfig.zoom": 11,
+        "mapConfig.locations[0].lat": 34.0135,
+        "mapConfig.locations[0].lng": -118.4947,
+        "mapConfig.locations[0].name": "Google Store Santa Monica",
+        "mapConfig.locations[0].description": "Your local destination for Google hardware.",
+        "mapConfig.locations[0].background": "#4285F4",
+        "mapConfig.locations[0].borderColor": "#FFFFFF",
+        "mapConfig.locations[0].glyphColor": "#FFFFFF",
+        "mapConfig.locations[1].lat": 34.1341,
+        "mapConfig.locations[1].lng": -118.3215,
+        "mapConfig.locations[1].name": "Griffith Observatory",
+        "mapConfig.locations[2].lat": 34.134,
+        "mapConfig.locations[2].lng": -118.3397,
+        "mapConfig.locations[2].name": "Hollywood Sign Viewpoint",
+        "mapConfig.locations[3].lat": 34.0453,
+        "mapConfig.locations[3].lng": -118.2673,
+        "mapConfig.locations[3].name": "Crypto.com Arena",
+        "mapConfig.locations[4].lat": 34.0639,
+        "mapConfig.locations[4].lng": -118.3592,
+        "mapConfig.locations[4].name": "LACMA",
+        "mapConfig.locations[5].lat": 33.985,
+        "mapConfig.locations[5].lng": -118.4729,
+        "mapConfig.locations[5].name": "Venice Beach Boardwalk"
+      }
+    }
+  }
+]

--- a/samples/go/examples/standard_catalog/0.9/chart.json
+++ b/samples/go/examples/standard_catalog/0.9/chart.json
@@ -1,0 +1,88 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "sales-dashboard",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "theme": {
+        "primaryColor": "#00BFFF",
+        "font": "Arial"
+      }
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "sales-dashboard",
+      "components": [
+        {
+          "id": "root",
+          "component": "Column",
+          "children": ["chart-title", "category-list"]
+        },
+        {
+          "id": "chart-title",
+          "component": "Text",
+          "text": {
+            "path": "/chart.title"
+          },
+          "variant": "h2"
+        },
+        {
+          "id": "category-list",
+          "component": "List",
+          "direction": "vertical",
+          "children": {
+            "componentId": "category-item-template",
+            "path": "/chart.items"
+          }
+        },
+        {
+          "id": "category-item-template",
+          "component": "Card",
+          "child": "item-row"
+        },
+        {
+          "id": "item-row",
+          "component": "Row",
+          "justify": "spaceBetween",
+          "children": ["item-label", "item-value"]
+        },
+        {
+          "id": "item-label",
+          "component": "Text",
+          "text": {
+            "path": "/label"
+          }
+        },
+        {
+          "id": "item-value",
+          "component": "Text",
+          "text": {
+            "path": "/value"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "sales-dashboard",
+      "path": "/",
+      "value": {
+        "chart.title": "Sales by Category",
+        "chart.items[0].label": "Apparel",
+        "chart.items[0].value": 41,
+        "chart.items[1].label": "Home Goods",
+        "chart.items[1].value": 15,
+        "chart.items[2].label": "Electronics",
+        "chart.items[2].value": 28,
+        "chart.items[3].label": "Health & Beauty",
+        "chart.items[3].value": 10,
+        "chart.items[4].label": "Other",
+        "chart.items[4].value": 6
+      }
+    }
+  }
+]

--- a/samples/go/examples/standard_catalog/0.9/map.json
+++ b/samples/go/examples/standard_catalog/0.9/map.json
@@ -1,0 +1,94 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "la-map-view",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "theme": {
+        "primaryColor": "#4285F4",
+        "font": "Roboto"
+      }
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "la-map-view",
+      "components": [
+        {
+          "id": "root",
+          "component": "Column",
+          "children": ["map-header", "map-image", "location-list"],
+          "align": "stretch"
+        },
+        {
+          "id": "map-header",
+          "component": "Text",
+          "text": "Points of Interest in Los Angeles",
+          "variant": "h2"
+        },
+        {
+          "id": "map-image",
+          "component": "Image",
+          "url": "https://maps.googleapis.com/maps/api/staticmap?center=Los+Angeles,CA&zoom=11&size=600x300&key=YOUR_API_KEY",
+          "fit": "cover"
+        },
+        {
+          "id": "location-list",
+          "component": "List",
+          "direction": "vertical",
+          "children": {
+            "componentId": "location-card-template",
+            "path": "/mapConfig.locations"
+          }
+        },
+        {
+          "id": "location-card-template",
+          "component": "Card",
+          "child": "location-details"
+        },
+        {
+          "id": "location-details",
+          "component": "Column",
+          "children": ["location-name", "location-description"]
+        },
+        {
+          "id": "location-name",
+          "component": "Text",
+          "text": {
+            "path": "/name"
+          },
+          "variant": "h4"
+        },
+        {
+          "id": "location-description",
+          "component": "Text",
+          "text": {
+            "path": "/description"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "la-map-view",
+      "path": "/",
+      "value": {
+        "mapConfig.locations[0].name": "Google Store Santa Monica",
+        "mapConfig.locations[0].description": "Your local destination for Google hardware.",
+        "mapConfig.locations[1].name": "Griffith Observatory",
+        "mapConfig.locations[1].description": "A public observatory with views of the Hollywood Sign.",
+        "mapConfig.locations[2].name": "Hollywood Sign Viewpoint",
+        "mapConfig.locations[2].description": "Iconic landmark in the Hollywood Hills.",
+        "mapConfig.locations[3].name": "Crypto.com Arena",
+        "mapConfig.locations[3].description": "Multi-purpose sports and entertainment arena.",
+        "mapConfig.locations[4].name": "LACMA",
+        "mapConfig.locations[4].description": "Los Angeles County Museum of Art.",
+        "mapConfig.locations[5].name": "Venice Beach Boardwalk",
+        "mapConfig.locations[5].description": "Famous oceanfront promenade."
+      }
+    }
+  }
+]

--- a/samples/go/rizzcharts/.env.example
+++ b/samples/go/rizzcharts/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your API key
+# Get your API key at: https://aistudio.google.com/apikey
+
+GEMINI_API_KEY=your_gemini_api_key_here
+
+# Optional: Change the model
+# GEMINI_MODEL=gemini-2.5-flash

--- a/samples/go/rizzcharts/README.md
+++ b/samples/go/rizzcharts/README.md
@@ -1,0 +1,97 @@
+# Rizzcharts - A2UI Ecommerce Dashboard Agent (Go)
+
+[中文文档](README.zh-CN.md)
+
+A demo agent server that visualizes ecommerce data (sales breakdowns, regional outliers) via the A2UI protocol, served over A2A (Agent-to-Agent) JSON-RPC.
+
+## Prerequisites
+
+- Go 1.22+
+- An OpenAI-compatible API key (Gemini, OpenAI, or any LiteLLM-compatible provider)
+
+## Configuration
+
+Create a `.env` file in this directory:
+
+```bash
+# Option 1: Gemini (default)
+GEMINI_API_KEY=your-gemini-api-key
+GEMINI_MODEL=gemini-2.5-flash
+
+# Option 2: OpenAI-compatible API
+OPENAI_API_KEY=your-api-key
+OPENAI_API_BASE=https://api.openai.com/v1
+LITELLM_MODEL=gpt-4o
+```
+
+## Run
+
+```bash
+cd samples/go/rizzcharts
+go run .
+```
+
+The server starts on `http://localhost:10002`.
+
+## Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /.well-known/agent-card.json` | A2A Agent Card (agent capabilities & metadata) |
+| `POST /` | A2A JSON-RPC endpoint (supports `message/send`) |
+
+## Usage Examples
+
+### Fetch Agent Card
+
+```bash
+curl http://localhost:10002/.well-known/agent-card.json | jq .
+```
+
+### Send a Message
+
+```bash
+curl -X POST http://localhost:10002/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "messageId": "msg-1",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "show my sales breakdown by product category for q3"}],
+        "kind": "message"
+      }
+    }
+  }'
+```
+
+### Example Queries
+
+- `"show my sales breakdown by product category for q3"` — Returns A2UI Chart component payload (doughnut/pie)
+- `"show revenue trends yoy by month"` — Returns A2UI Chart component payload
+- `"were there any outlier stores in the northeast region"` — Returns A2UI Map component payload
+
+## Architecture
+
+```
+main.go      - HTTP server, A2A protocol handling
+agent.go     - LLM interaction, tool-calling loop
+tools.go     - Mock data tools (get_sales_data, get_store_sales)
+```
+
+The agent uses the A2UI Go SDK to:
+1. Build a system prompt with A2UI schema and catalog definitions
+2. Call an LLM via OpenAI-compatible API with tool definitions
+3. Execute tools and feed results back to the LLM
+4. Parse `<a2ui-json>` blocks from the LLM response
+5. Return A2UI messages as A2A data parts
+
+## Supported Skills
+
+| Skill | Description |
+|-------|-------------|
+| `view_sales_by_category` | Pie chart of sales by product category |
+| `view_regional_outliers` | Map showing regional sales outliers |

--- a/samples/go/rizzcharts/README.zh-CN.md
+++ b/samples/go/rizzcharts/README.zh-CN.md
@@ -1,0 +1,97 @@
+# Rizzcharts - A2UI 电商仪表盘 Agent（Go）
+
+[English](README.md)
+
+一个演示用的 Agent 服务，通过 A2UI 协议可视化电商数据（销售分布、区域异常值），基于 A2A（Agent-to-Agent）JSON-RPC 协议提供服务。
+
+## 前置条件
+
+- Go 1.22+
+- 一个兼容 OpenAI 接口的 API Key（Gemini、OpenAI 或任何 LiteLLM 兼容的服务商）
+
+## 配置
+
+在本目录下创建 `.env` 文件：
+
+```bash
+# 方案一：使用 Gemini（默认）
+GEMINI_API_KEY=your-gemini-api-key
+GEMINI_MODEL=gemini-2.5-flash
+
+# 方案二：使用 OpenAI 兼容接口
+OPENAI_API_KEY=your-api-key
+OPENAI_API_BASE=https://api.openai.com/v1
+LITELLM_MODEL=gpt-4o
+```
+
+## 运行
+
+```bash
+cd samples/go/rizzcharts
+go run .
+```
+
+服务启动后监听 `http://localhost:10002`。
+
+## 接口
+
+| 接口 | 说明 |
+|------|------|
+| `GET /.well-known/agent-card.json` | A2A Agent Card（Agent 能力与元信息） |
+| `POST /` | A2A JSON-RPC 端点（支持 `message/send` 方法） |
+
+## 使用示例
+
+### 获取 Agent Card
+
+```bash
+curl http://localhost:10002/.well-known/agent-card.json | jq .
+```
+
+### 发送消息
+
+```bash
+curl -X POST http://localhost:10002/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "messageId": "msg-1",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "show my sales breakdown by product category for q3"}],
+        "kind": "message"
+      }
+    }
+  }'
+```
+
+### 示例查询
+
+- `"show my sales breakdown by product category for q3"` — 返回 A2UI Chart 组件载荷（环形图/饼图）
+- `"show revenue trends yoy by month"` — 返回 A2UI Chart 组件载荷
+- `"were there any outlier stores in the northeast region"` — 返回 A2UI Map 组件载荷
+
+## 架构
+
+```
+main.go      - HTTP 服务器，A2A 协议处理
+agent.go     - LLM 交互，工具调用循环
+tools.go     - 模拟数据工具（get_sales_data、get_store_sales）
+```
+
+Agent 使用 A2UI Go SDK 实现以下流程：
+1. 构建包含 A2UI schema 和组件目录定义的系统提示词
+2. 通过 OpenAI 兼容接口调用 LLM，附带工具定义
+3. 执行工具调用并将结果反馈给 LLM
+4. 从 LLM 响应中解析 `<a2ui-json>` 块
+5. 以 A2A data parts 形式返回 A2UI 消息
+
+## 支持的能力
+
+| 能力 | 说明 |
+|------|------|
+| `view_sales_by_category` | 按品类的销售饼图 |
+| `view_regional_outliers` | 区域销售异常值地图 |

--- a/samples/go/rizzcharts/agent.go
+++ b/samples/go/rizzcharts/agent.go
@@ -1,0 +1,329 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// RizzchartsAgent wraps an OpenAI-compatible LLM with A2UI system prompt and tool calling.
+type RizzchartsAgent struct {
+	apiKey       string
+	apiBase      string
+	model        string
+	systemPrompt string
+	httpClient   *http.Client
+}
+
+// NewRizzchartsAgent creates a new agent.
+func NewRizzchartsAgent(apiKey, apiBase, model, systemPrompt string) *RizzchartsAgent {
+	return &RizzchartsAgent{
+		apiKey:       apiKey,
+		apiBase:      strings.TrimRight(apiBase, "/"),
+		model:        model,
+		systemPrompt: systemPrompt,
+		httpClient:   &http.Client{},
+	}
+}
+
+// Close is a no-op for the HTTP-based agent (satisfies cleanup pattern).
+func (a *RizzchartsAgent) Close() {}
+
+// openAI request/response types
+
+type chatMessage struct {
+	Role       string     `json:"role"`
+	Content    string     `json:"content,omitempty"`
+	ToolCalls  []toolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+}
+
+type toolCall struct {
+	ID       string       `json:"id"`
+	Type     string       `json:"type"`
+	Function functionCall `json:"function"`
+}
+
+type functionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type toolDef struct {
+	Type     string      `json:"type"`
+	Function toolFuncDef `json:"function"`
+}
+
+type toolFuncDef struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Parameters  any    `json:"parameters"`
+}
+
+type chatRequest struct {
+	Model    string        `json:"model"`
+	Messages []chatMessage `json:"messages"`
+	Tools    []toolDef     `json:"tools,omitempty"`
+}
+
+type chatResponse struct {
+	Choices []chatChoice `json:"choices"`
+	Error   *apiError    `json:"error,omitempty"`
+}
+
+type chatChoice struct {
+	Message      chatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type apiError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+// tools definitions for the OpenAI tools format
+var openAITools = []toolDef{
+	{
+		Type: "function",
+		Function: toolFuncDef{
+			Name:        "get_sales_data",
+			Description: "Gets the sales data. Returns sales breakdown by product category.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"time_period": map[string]any{
+						"type":        "string",
+						"description": "The time period to get sales data for (e.g. 'Q1', 'year'). Defaults to 'year'.",
+					},
+				},
+			},
+		},
+	},
+	{
+		Type: "function",
+		Function: toolFuncDef{
+			Name:        "get_store_sales",
+			Description: "Gets individual store sales with locations. Returns store locations with sales data and outlier information.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"region": map[string]any{
+						"type":        "string",
+						"description": "The region to get store sales for. Defaults to 'all'.",
+					},
+				},
+			},
+		},
+	},
+}
+
+// Chat sends a user message and handles the multi-turn tool-calling loop.
+func (a *RizzchartsAgent) Chat(ctx context.Context, userMessage string) ([]map[string]any, error) {
+	messages := []chatMessage{
+		{Role: "system", Content: a.systemPrompt},
+		{Role: "user", Content: userMessage},
+	}
+
+	maxIterations := 10
+	for i := 0; i < maxIterations; i++ {
+		resp, err := a.callChatAPI(ctx, messages)
+		if err != nil {
+			return nil, fmt.Errorf("chat API call failed: %w", err)
+		}
+
+		if resp.Error != nil {
+			return nil, fmt.Errorf("API error: %s", resp.Error.Message)
+		}
+
+		if len(resp.Choices) == 0 {
+			return nil, fmt.Errorf("no choices in API response")
+		}
+
+		choice := resp.Choices[0]
+		assistantMsg := choice.Message
+
+		// Append assistant message to history
+		messages = append(messages, assistantMsg)
+
+		// Check for tool calls
+		if len(assistantMsg.ToolCalls) > 0 {
+			for _, tc := range assistantMsg.ToolCalls {
+				result := a.executeTool(tc.Function.Name, tc.Function.Arguments)
+				resultJSON, _ := json.Marshal(result)
+				messages = append(messages, chatMessage{
+					Role:       "tool",
+					Content:    string(resultJSON),
+					ToolCallID: tc.ID,
+				})
+			}
+			continue
+		}
+
+		// No tool calls → final text response
+		text := assistantMsg.Content
+		if text == "" {
+			return nil, fmt.Errorf("no text response from model")
+		}
+
+		log.Printf("Model response:\n%s", text)
+		return parseA2UIFromText(text)
+	}
+
+	return nil, fmt.Errorf("exceeded maximum tool calling iterations")
+}
+
+func (a *RizzchartsAgent) callChatAPI(ctx context.Context, messages []chatMessage) (*chatResponse, error) {
+	reqBody := chatRequest{
+		Model:    a.model,
+		Messages: messages,
+		Tools:    openAITools,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := a.apiBase + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+a.apiKey)
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var chatResp chatResponse
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return nil, fmt.Errorf("failed to parse API response: %w", err)
+	}
+
+	return &chatResp, nil
+}
+
+func (a *RizzchartsAgent) executeTool(name string, argsJSON string) map[string]any {
+	var args map[string]any
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		log.Printf("Failed to parse tool args: %v", err)
+		args = map[string]any{}
+	}
+
+	switch name {
+	case "get_sales_data":
+		timePeriod := "year"
+		if tp, ok := args["time_period"].(string); ok && tp != "" {
+			timePeriod = tp
+		}
+		log.Printf("Executing tool: get_sales_data(time_period=%s)", timePeriod)
+		return getSalesData(timePeriod)
+
+	case "get_store_sales":
+		region := "all"
+		if r, ok := args["region"].(string); ok && r != "" {
+			region = r
+		}
+		log.Printf("Executing tool: get_store_sales(region=%s)", region)
+		return getStoreSales(region)
+
+	default:
+		log.Printf("Unknown tool: %s", name)
+		return map[string]any{"error": fmt.Sprintf("unknown tool: %s", name)}
+	}
+}
+
+// a2uiOpenRe matches <a2ui-json> with optional whitespace (some LLMs add spaces inside tags).
+var a2uiOpenRe = regexp.MustCompile(`<\s*a2ui-json\s*>`)
+
+// a2uiCloseRe matches </a2ui-json> with optional whitespace.
+var a2uiCloseRe = regexp.MustCompile(`<\s*/\s*a2ui-json\s*>`)
+
+// parseA2UIFromText extracts A2UI JSON blocks from the model's text response.
+func parseA2UIFromText(text string) ([]map[string]any, error) {
+	var allMessages []map[string]any
+	remaining := text
+
+	for {
+		openLoc := a2uiOpenRe.FindStringIndex(remaining)
+		if openLoc == nil {
+			break
+		}
+		remaining = remaining[openLoc[1]:]
+
+		closeLoc := a2uiCloseRe.FindStringIndex(remaining)
+		if closeLoc == nil {
+			break
+		}
+		jsonStr := remaining[:closeLoc[0]]
+		remaining = remaining[closeLoc[1]:]
+
+		jsonStr = cleanJSON(jsonStr)
+
+		var raw any
+		if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
+			log.Printf("Failed to parse A2UI JSON block: %v", err)
+			continue
+		}
+
+		switch v := raw.(type) {
+		case []any:
+			for _, item := range v {
+				if m, ok := item.(map[string]any); ok {
+					allMessages = append(allMessages, m)
+				}
+			}
+		case map[string]any:
+			allMessages = append(allMessages, v)
+		}
+	}
+
+	if len(allMessages) == 0 {
+		return nil, fmt.Errorf("no A2UI JSON blocks found in response")
+	}
+
+	return allMessages, nil
+}
+
+func cleanJSON(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "```json")
+	s = strings.TrimPrefix(s, "```")
+	s = strings.TrimSuffix(s, "```")
+	s = strings.TrimSpace(s)
+	return s
+}

--- a/samples/go/rizzcharts/go.mod
+++ b/samples/go/rizzcharts/go.mod
@@ -1,0 +1,12 @@
+module github.com/AGenUI/AGenUI/samples/go/rizzcharts
+
+go 1.22
+
+require github.com/AGenUI/AGenUI/agent_sdks/go v0.0.0
+
+require (
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)
+
+replace github.com/AGenUI/AGenUI/agent_sdks/go => ../../../agent_sdks/go

--- a/samples/go/rizzcharts/go.sum
+++ b/samples/go/rizzcharts/go.sum
@@ -1,0 +1,6 @@
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/samples/go/rizzcharts/main.go
+++ b/samples/go/rizzcharts/main.go
@@ -1,0 +1,406 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main implements a Go-based rizzcharts agent server that serves
+// A2UI-powered ecommerce dashboard visualizations via the A2A protocol.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	a2ui "github.com/AGenUI/AGenUI/agent_sdks/go"
+	"github.com/AGenUI/AGenUI/agent_sdks/go/basiccatalog"
+	"github.com/AGenUI/AGenUI/agent_sdks/go/schema"
+)
+
+const (
+	host = "localhost"
+	port = 10002
+)
+
+const roleDescription = `You are an expert A2UI Ecommerce Dashboard analyst. Your primary function is to translate user requests for ecommerce data into A2UI JSON payloads to display charts and visualizations. You MUST output the A2UI JSON payload wrapped in <a2ui-json> and </a2ui-json> tags.
+`
+
+const workflowDescription = `Your task is to analyze the user's request, fetch the necessary data, select the correct generic template, and output the corresponding A2UI JSON payload.
+
+1.  **Analyze the Request:** Determine the user's intent (Visual Chart vs. Geospatial Map).
+    * "show my sales breakdown by product category for q3" -> **Intent:** Chart.
+    * "show revenue trends yoy by month" -> **Intent:** Chart.
+    * "were there any outlier stores in the northeast region" -> **Intent:** Map.
+
+2.  **Fetch Data:** Select and use the appropriate tool to retrieve the necessary data.
+    * Use **get_sales_data** for general sales, revenue, and product category trends (typically for Charts).
+    * Use **get_store_sales** for regional performance, store locations, and geospatial outliers (typically for Maps).
+
+3.  **Select Example:** Based on the intent, choose the correct example block to use as your template.
+    * **Intent** (Chart/Data Viz) -> Use the chart example.
+    * **Intent** (Map/Geospatial) -> Use the map example.
+
+4.  **Construct the JSON Payload:**
+    * Use the **entire** JSON array from the chosen example as the base.
+    * **Generate a new surfaceId:** You MUST generate a new, unique surfaceId for this request. This new ID must be used for the surfaceId in all three messages within the JSON array (createSurface, updateComponents, updateDataModel).
+    * **Update the title Text:** You MUST update the text property of the Text component (the component with id: "page_header") to accurately reflect the specific user query.
+    * Ensure the generated JSON perfectly matches the A2UI specification.
+
+5.  **Output the JSON:** Wrap the constructed A2UI JSON array in <a2ui-json> and </a2ui-json> tags.
+`
+
+const uiDescription = `**Core Objective:** To provide a dynamic and interactive dashboard by constructing UI surfaces with the appropriate visualization components based on user queries.
+
+**Key Components & Examples:**
+
+You will be provided a schema that defines the A2UI message structure and two key generic component templates for displaying data.
+
+1.  **Charts:** Used for requests about sales breakdowns, revenue performance, comparisons, or trends.
+    * **Template:** Use the chart example.
+2.  **Maps:** Used for requests about regional data, store locations, geography-based performance, or regional outliers.
+    * **Template:** Use the map example.
+
+You will also use layout components like Column (as the root) and Text (to provide a title).
+`
+
+// getSourceDir returns the directory of the current source file.
+func getSourceDir() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Dir(filename)
+}
+
+func buildSystemPrompt() (string, error) {
+	sourceDir := getSourceDir()
+	version := schema.Version09
+
+	catalogPath := filepath.Join(sourceDir, "..", "catalog_schemas", "0.9", "rizzcharts_catalog_definition.json")
+	examplesPath := filepath.Join(sourceDir, "..", "examples", "rizzcharts_catalog", "0.9")
+	stdExamplesPath := filepath.Join(sourceDir, "..", "examples", "standard_catalog", "0.9")
+
+	rizzchartsCatalog, err := schema.NewCatalogConfigFromPath("rizzcharts", catalogPath, examplesPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create rizzcharts catalog config: %w", err)
+	}
+
+	basicCatalogCfg := basiccatalog.GetConfig(version, stdExamplesPath)
+
+	mgr, err := schema.NewA2uiSchemaManager(schema.A2uiSchemaManagerConfig{
+		Version:               version,
+		Catalogs:              []*schema.CatalogConfig{rizzchartsCatalog, &basicCatalogCfg},
+		AcceptsInlineCatalogs: true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create schema manager: %w", err)
+	}
+
+	prompt := mgr.GenerateSystemPrompt(a2ui.SystemPromptOptions{
+		RoleDescription:     roleDescription,
+		WorkflowDescription: workflowDescription,
+		UIDescription:       uiDescription,
+		IncludeSchema:       true,
+		IncludeExamples:     true,
+		ValidateExamples:    false,
+	})
+
+	return prompt, nil
+}
+
+// agentCardJSON returns the agent card as a JSON-serializable map.
+func agentCardJSON() map[string]any {
+	return map[string]any{
+		"name":        "Ecommerce Dashboard Agent (Go)",
+		"description": "This agent visualizes ecommerce data, showing sales breakdowns, YOY revenue performance, and regional sales outliers. Powered by Go.",
+		"url":         fmt.Sprintf("http://%s:%d", host, port),
+		"version":     "1.0.0",
+		"capabilities": map[string]any{
+			"streaming": false,
+			"extensions": []any{
+				map[string]any{
+					"uri": "https://a2ui.org/a2a-extension/a2ui/v0.9",
+					"requiredFields": map[string]any{
+						"supported_catalog_ids": []string{
+							"https://a2ui.org/specification/v0_9/json/basic_catalog.json",
+						},
+						"accepts_inline_catalogs": true,
+					},
+				},
+			},
+		},
+		"defaultInputModes":  []string{"text", "text/plain"},
+		"defaultOutputModes": []string{"text", "text/plain"},
+		"skills": []any{
+			map[string]any{
+				"id":          "view_sales_by_category",
+				"name":        "View Sales by Category",
+				"description": "Displays a pie chart of sales broken down by product category for a given time period.",
+				"tags":        []string{"sales", "breakdown", "category", "pie chart", "revenue"},
+				"examples":    []string{"show my sales breakdown by product category for q3"},
+			},
+			map[string]any{
+				"id":          "view_regional_outliers",
+				"name":        "View Regional Sales Outliers",
+				"description": "Displays a map showing regional sales outliers or store-level performance.",
+				"tags":        []string{"sales", "regional", "outliers", "stores", "map"},
+				"examples":    []string{"were there any outlier stores in the northeast region"},
+			},
+		},
+	}
+}
+
+// loadEnvFile loads environment variables from a .env file (simple key=value format).
+// NOTE: This is a minimal loader for demo purposes. It does not handle quoted values,
+// multi-line values, export prefixes, or variable interpolation.
+func loadEnvFile(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+		// Only set if not already defined in environment
+		if os.Getenv(key) == "" {
+			os.Setenv(key, val)
+		}
+	}
+}
+
+func main() {
+	// Load .env from current dir and source dir
+	loadEnvFile(".env")
+	loadEnvFile(filepath.Join(getSourceDir(), ".env"))
+
+	// Support OpenAI-compatible API (same as Python restaurant_finder)
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	apiBase := os.Getenv("OPENAI_API_BASE")
+	modelName := os.Getenv("LITELLM_MODEL")
+
+	// Fallback to Gemini-style env vars
+	if apiKey == "" {
+		apiKey = os.Getenv("GEMINI_API_KEY")
+	}
+	if apiBase == "" {
+		apiBase = "https://generativelanguage.googleapis.com/v1beta/openai"
+	}
+	if modelName == "" {
+		modelName = os.Getenv("GEMINI_MODEL")
+	}
+	if modelName == "" {
+		modelName = "gemini-2.5-flash"
+	}
+
+	// Strip "openai/" prefix from model name (LiteLLM convention)
+	modelName = strings.TrimPrefix(modelName, "openai/")
+
+	if apiKey == "" {
+		log.Fatal("API key required. Set OPENAI_API_KEY or GEMINI_API_KEY in .env or environment.")
+	}
+
+	log.Printf("Using model: %s", modelName)
+	log.Printf("Using API base: %s", apiBase)
+
+	log.Println("Building A2UI system prompt...")
+	systemPrompt, err := buildSystemPrompt()
+	if err != nil {
+		log.Fatalf("Failed to build system prompt: %v", err)
+	}
+	log.Printf("System prompt built (%d chars)", len(systemPrompt))
+
+	agent := NewRizzchartsAgent(apiKey, apiBase, modelName, systemPrompt)
+	defer agent.Close()
+
+	mux := http.NewServeMux()
+
+	// Agent Card endpoint (A2A protocol)
+	mux.HandleFunc("/.well-known/agent-card.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "*")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		json.NewEncoder(w).Encode(agentCardJSON())
+	})
+
+	// A2A message endpoint
+	// NOTE: This is a minimal A2A JSON-RPC implementation for demo purposes only.
+	// It supports message/send but omits streaming, task lifecycle, and other
+	// A2A v1.0 methods. For production use, consider the official Go SDK:
+	// https://github.com/a2aproject/a2a-go
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		setCORS(w)
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var reqBody map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			writeJSONRPCError(w, nil, -32700, "Parse error")
+			return
+		}
+
+		method, _ := reqBody["method"].(string)
+		id := reqBody["id"]
+
+		if method != "message/send" {
+			writeJSONRPCError(w, id, -32601, fmt.Sprintf("Method not found: %s", method))
+			return
+		}
+
+		// Extract user message from A2A params
+		userText := extractUserText(reqBody)
+		if userText == "" {
+			writeJSONRPCError(w, id, -32602, "No text message found in request")
+			return
+		}
+
+		log.Printf("Received user message: %s", userText)
+
+		// Call the agent
+		messages, err := agent.Chat(r.Context(), userText)
+		if err != nil {
+			log.Printf("Agent error: %v", err)
+			writeJSONRPCError(w, id, -32000, fmt.Sprintf("Agent error: %v", err))
+			return
+		}
+
+		// Build A2A response
+		writeA2AResponse(w, id, messages)
+	})
+
+	addr := fmt.Sprintf("%s:%d", host, port)
+	log.Printf("Starting Go Rizzcharts Agent on http://%s", addr)
+	log.Printf("Agent Card: http://%s/.well-known/agent-card.json", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatalf("Server failed: %v", err)
+	}
+}
+
+// WARNING: Wildcard CORS is used here for demo convenience only.
+// Do not use wildcard CORS in production — restrict origins to known domains.
+func setCORS(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "*")
+}
+
+// extractUserText extracts the user text message from the A2A JSON-RPC request.
+func extractUserText(reqBody map[string]any) string {
+	params, _ := reqBody["params"].(map[string]any)
+	if params == nil {
+		return ""
+	}
+	msg, _ := params["message"].(map[string]any)
+	if msg == nil {
+		return ""
+	}
+	parts, _ := msg["parts"].([]any)
+	for _, part := range parts {
+		p, _ := part.(map[string]any)
+		if p == nil {
+			continue
+		}
+		if kind, _ := p["kind"].(string); kind == "text" {
+			if text, ok := p["text"].(string); ok {
+				return text
+			}
+		}
+		// Handle JSON/data parts (like UI events)
+		if kind, _ := p["kind"].(string); kind == "data" {
+			if data, ok := p["data"].(map[string]any); ok {
+				b, _ := json.Marshal(data)
+				return string(b)
+			}
+		}
+	}
+	return ""
+}
+
+// writeA2AResponse writes a JSON-RPC success response with A2UI data parts.
+func writeA2AResponse(w http.ResponseWriter, id any, messages []map[string]any) {
+	// Build parts - each A2UI message becomes a data part
+	parts := make([]any, 0, len(messages))
+	for _, msg := range messages {
+		parts = append(parts, map[string]any{
+			"kind": "data",
+			"data": msg,
+			"metadata": map[string]any{
+				"mimeType": "application/json+a2ui",
+			},
+		})
+	}
+
+	result := map[string]any{
+		"kind": "task",
+		"id":   "task-1",
+		"status": map[string]any{
+			"state": "completed",
+			"message": map[string]any{
+				"messageId": "resp-1",
+				"role":      "agent",
+				"parts":     parts,
+				"kind":      "message",
+			},
+		},
+	}
+
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result":  result,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// writeJSONRPCError writes a JSON-RPC error response.
+func writeJSONRPCError(w http.ResponseWriter, id any, code int, message string) {
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK) // JSON-RPC errors are 200 with error in body
+	json.NewEncoder(w).Encode(resp)
+}

--- a/samples/go/rizzcharts/tools.go
+++ b/samples/go/rizzcharts/tools.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+// Copyright 2026 The AGenUI Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// getStoreSales returns mock store sales data.
+func getStoreSales(region string) map[string]any {
+	return map[string]any{
+		"center": map[string]any{"lat": 34.0, "lng": -118.2437},
+		"zoom":   10,
+		"locations": []any{
+			map[string]any{
+				"lat":            34.0195,
+				"lng":            -118.4912,
+				"name":           "Santa Monica Branch",
+				"description":    "High traffic coastal location.",
+				"outlier_reason": "Yes, 15% sales over baseline",
+				"background":     "#4285F4",
+				"borderColor":    "#FFFFFF",
+				"glyphColor":     "#FFFFFF",
+			},
+			map[string]any{"lat": 34.0488, "lng": -118.2518, "name": "Downtown Flagship"},
+			map[string]any{"lat": 34.1016, "lng": -118.3287, "name": "Hollywood Boulevard Store"},
+			map[string]any{"lat": 34.1478, "lng": -118.1445, "name": "Pasadena Location"},
+			map[string]any{"lat": 33.7701, "lng": -118.1937, "name": "Long Beach Outlet"},
+			map[string]any{"lat": 34.0736, "lng": -118.4004, "name": "Beverly Hills Boutique"},
+		},
+	}
+}
+
+// getSalesData returns mock sales data.
+func getSalesData(timePeriod string) map[string]any {
+	return map[string]any{
+		"sales_data": []any{
+			map[string]any{
+				"label": "Apparel",
+				"value": 41,
+				"drillDown": []any{
+					map[string]any{"label": "Tops", "value": 31},
+					map[string]any{"label": "Bottoms", "value": 38},
+					map[string]any{"label": "Outerwear", "value": 20},
+					map[string]any{"label": "Footwear", "value": 11},
+				},
+			},
+			map[string]any{
+				"label": "Home Goods",
+				"value": 15,
+				"drillDown": []any{
+					map[string]any{"label": "Pillow", "value": 8},
+					map[string]any{"label": "Coffee Maker", "value": 16},
+					map[string]any{"label": "Area Rug", "value": 3},
+					map[string]any{"label": "Bath Towels", "value": 14},
+				},
+			},
+			map[string]any{
+				"label": "Electronics",
+				"value": 28,
+				"drillDown": []any{
+					map[string]any{"label": "Phones", "value": 25},
+					map[string]any{"label": "Laptops", "value": 27},
+					map[string]any{"label": "TVs", "value": 21},
+					map[string]any{"label": "Other", "value": 27},
+				},
+			},
+			map[string]any{"label": "Health & Beauty", "value": 10},
+			map[string]any{"label": "Other", "value": 6},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Add Go Agent SDK (`agent_sdks/go/`) imported via git subtree from [google/A2UI](https://github.com/google/A2UI) fork
- Add rizzcharts Go sample (`samples/go/rizzcharts/`) demonstrating A2UI-powered ecommerce dashboard agent
- Update Go module paths to `github.com/AGenUI/AGenUI/...` namespace
- Add AGenUI copyright declaration in NOTICE file per Apache 2.0 convention

## Details
The Go Agent SDK provides:
- A2UI message parsing (streaming and non-streaming)
- Schema management with catalog support (basic + custom catalogs)
- System prompt generation for LLM-based agents
- Conformance test suite

The rizzcharts sample demonstrates a complete A2A-compatible agent server with chart and map visualizations.

## Test plan
- [x] `go build ./...` passes for both `agent_sdks/go/` and `samples/go/rizzcharts/`
- [ ] Run existing Go tests: `cd agent_sdks/go && go test ./...`
- [ ] Verify rizzcharts agent starts and serves agent card