### PR TITLE
fix(harmony):Fix memory leak caused by Modal closure

### DIFF
--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/modal_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/modal_component.cpp
@@ -147,6 +147,7 @@ void ModalComponent::showDialog() {
         // Recover the bound instance and clear its handle.
         auto* component = static_cast<ModalComponent*>(OH_ArkUI_DialogDismissEvent_GetUserData(event));
         if (component) {
+            component->m_dialogAPI->dispose(component->m_dialogHandle);
             component->m_dialogHandle = nullptr;
             HM_LOGI("handle reset, id=%s", component->m_id.c_str());
         }


### PR DESCRIPTION
## Description
When the Modal dialog closes, only the pointer is assigned as null without calling dispose to release resources; when the dialog pops up again later, the pointer gets reassigned to a new value, which causes a memory leak. The leak amounts to approximately 5MB per hundred times.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [x] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [x] Code compiles without errors on affected platform(s)
- [x] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)