### PR TITLE
fix(skill): fix YAML frontmatter parsing

### DIFF
--- a/skills/a2ui-generation/SKILL.md
+++ b/skills/a2ui-generation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: a2ui-generation
-description: Design and generate A2UI `updateComponents` and `updateDataModel` payloads for three modes: DTO component, non-DTO component, and non-DTO page. Use when asked to create or refine A2UI cards, components, or pages from DTO/JSON/business data, generate Python transformer code for DTO-driven components, iterate on existing A2UI output files by diff, improve mobile UI quality, or validate A2UI rules such as `surfaceId`, `root`, path binding, and component-vs-page boundaries.
+description: |
+  Design and generate A2UI updateComponents and updateDataModel payloads for three modes (DTO component, non-DTO component, non-DTO page). Use when asked to create or refine A2UI cards, components, or pages from DTO/JSON/business data, generate Python transformer code for DTO-driven components, iterate on existing A2UI output files by diff, improve mobile UI quality, or validate A2UI rules such as surfaceId, root, path binding, and component-vs-page boundaries.
+  Trigger words: "A2UI", "a2ui", "generate card", "generate page", "UI component", "AGenUI"
 ---
 
 # A2UI Generation
@@ -213,6 +215,16 @@ Only truly irreplaceable business invariants that scripts cannot fully substitut
 - The layout rationale must cover at minimum: main sections, visual focal point, content rhythm, key component relationships, and the role of images/charts
 - Before formal output, at least `1` explicit improvement round is required; the first version in your head must not be delivered directly as the final first draft
 - This explicit improvement round defaults to prioritizing premium feel, design quality, and overall completeness — not just literal additions
+- **Component allowlist**: Only use component names defined in `docs/component-catalog.md`.
+  Do NOT invent, translate, or import names from React / Flutter / SwiftUI / Tailwind.
+  Allowed components: `Column`, `Row`, `List`, `Card`, `Tabs`, `Modal`, `Divider`, `Carousel`, `Text`, `RichText`, `Markdown`, `Image`, `Icon`, `Video`, `AudioPlayer`, `Lottie`, `Web`, `Button`, `TextField`, `CheckBox`, `ChoicePicker`, `Slider`, `DateTimeInput`, `Chart`, `Table`.
+  Common wrong names and their correct replacements:
+  - "Container" / "Box" / "Wrapper" → use `Card` (bordered) or `Column` with padding
+  - "Stack" / "VStack" / "HStack" → use `Column` (vertical) or `Row` (horizontal)
+  - "Spacer" → use margin / padding on adjacent components
+  - "Badge" / "Chip" / "Tag" → use `Text` with rounded background styles
+  - "Accordion" → use `Tabs` or toggle visibility via styles `display: "none"`
+  - "BarChart" / "LineChart" / "DonutChart" → use `Chart` with `chartType: "bar" | "line" | "donut" | "bar_grouped"`
 
 ## Resources
 

--- a/skills/a2ui-generation/docs/component-catalog.md
+++ b/skills/a2ui-generation/docs/component-catalog.md
@@ -100,6 +100,14 @@ Dialog. `trigger` is the triggering component id; `content` is the dialog body c
 {"id": "modal1", "component": "Modal", "trigger": "btn1", "content": "modal_body"}
 ```
 
+#### `Carousel`
+
+Image carousel. `content` is an array of image URLs. `autoplay` defaults to `false`; `draggable` defaults to `true`.
+
+```json
+{"id": "carousel1", "component": "Carousel", "content": ["/images/slide1.jpg", "/images/slide2.jpg"], "autoplay": false, "draggable": true}
+```
+
 ### Content Components
 
 #### `Text`
@@ -212,31 +220,23 @@ Built-in icon. `name` supports a literal value or `{"path": "..."}` dynamic bind
 
 ### Chart Components
 
-#### `BarChart`
+#### `Chart`
+
+Unified chart component. Use `chartType` to select visualization type.
 
 ```json
-{"id": "bc1", "component": "BarChart", "title": {"path": "/data/chartTitle"}, "data": {"path": "/data/chartData"}}
+{"id": "chart1", "component": "Chart", "chartType": "bar", "title": {"path": "/data/chartTitle"}, "data": {"path": "/data/chartData"}}
 ```
 
-`data` structure:
+`chartType` enum: `"bar"` | `"line"` | `"donut"` | `"bar_grouped"`
+
+`data` structure (bar / line / bar_grouped):
 
 ```json
 {"xAxis": ["Label1", "Label2"], "yAxis": ["Low", "Mid", "High"], "series": [{"name": "Series Name", "data": [{"value": 1.5, "label": "Display Text"}]}]}
 ```
 
-#### `LineChart`
-
-```json
-{"id": "lc1", "component": "LineChart", "title": {"path": "/data/lineTitle"}, "data": {"path": "/data/lineData"}}
-```
-
-#### `DonutChart`
-
-```json
-{"id": "dc1", "component": "DonutChart", "title": {"path": "/data/donutTitle"}, "data": {"path": "/data/donutData"}}
-```
-
-`data` structure:
+`data` structure (donut):
 
 ```json
 {"series": [{"name": "", "data": [{"label": "Category A", "value": 30}, {"label": "Category B", "value": 70}]}]}

--- a/skills/a2ui-generation/scripts/validate_a2ui.py
+++ b/skills/a2ui-generation/scripts/validate_a2ui.py
@@ -30,6 +30,13 @@ BUTTONISH_TEXT_PATH_RE = re.compile(
 
 UNSUPPORTED_STYLE_KEYS = {"flex-basis", "gap", "box-shadow", "position", "z-index"}
 ALLOWED_FONT_SIZES = {"24px", "28px", "32px", "36px", "40px"}
+ALLOWED_COMPONENTS = {
+    "Column", "Row", "List", "Card", "Tabs", "Modal", "Divider", "Carousel",
+    "Text", "RichText", "Markdown", "Image", "Icon", "Video",
+    "AudioPlayer", "Lottie", "Web",
+    "Button", "TextField", "CheckBox", "ChoicePicker", "Slider", "DateTimeInput",
+    "Chart", "Table",
+}
 
 
 def _normalize_px(value: Any) -> str | None:
@@ -402,6 +409,12 @@ def validate(comp: dict, data: dict, overrides: dict[str, Any] | None = None) ->
     for component in components:
         cid = component.get("id", "")
         ctype = component.get("component", "")
+
+        if ctype and ctype not in ALLOWED_COMPONENTS:
+            errors.append(
+                f"{cid or '?'}: unknown component '{ctype}'; "
+                f"allowed: {sorted(ALLOWED_COMPONENTS)}"
+            )
 
         if not cid:
             preview = json.dumps(component, ensure_ascii=False)[:120]


### PR DESCRIPTION
- Use YAML block scalar for description to avoid colon-space triggering BLOCK_AS_IMPLICIT_KEY parse error in skills CLI

## Description

<!-- Brief description of what this PR does and why -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [ ] HarmonyOS
- [ ] C++ Core Engine
- [x] Documentation / CI

## Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [ ] Code compiles without errors on affected platform(s)
- [ ] I have tested on relevant device(s) or simulator(s)
- [x] Documentation updated (if applicable)