### PR TITLE
fix(list): enable horizontal scrolling by defaulting flex-shrink:0

### DIFF
--- a/core/src/surface/virtual_dom/agenui_virtual_dom_node.cpp
+++ b/core/src/surface/virtual_dom/agenui_virtual_dom_node.cpp
@@ -145,6 +145,32 @@ void VirtualDOMNode::setSnapshot(const ComponentSnapshot& snapshot, const std::s
     // Must be called before StyleDefaults loop to avoid being overwritten.
     TabsYogaHelper::injectFlexGrowIfNeeded(*_snapshot);
 
+    // Inject flex-shrink: 0 for children of scroll containers — Yoga's
+    // YGOverflowScroll does NOT inhibit flex-shrink unlike browser behavior.
+    if (_parent && _snapshot->styles.find("flex-shrink") == _snapshot->styles.end()) {
+        bool parentIsScrollable = false;
+        // Check parent Yoga node (valid after parent's applySnapshot)
+        if (_parent->_yogaNode) {
+            YGOverflow parentOverflow = YGNodeStyleGetOverflow(_parent->_yogaNode->get());
+            if (parentOverflow == YGOverflowScroll) {
+                parentIsScrollable = true;
+            }
+        }
+        // Fallback: check parent snapshot (before parent's Yoga conversion)
+        if (!parentIsScrollable && _parent->_snapshot) {
+            auto overflowIt = _parent->_snapshot->styles.find("overflow");
+            if (overflowIt != _parent->_snapshot->styles.end() &&
+                overflowIt->second.isString() &&
+                overflowIt->second.asString() == "scroll") {
+                parentIsScrollable = true;
+            }
+        }
+        if (parentIsScrollable) {
+            _snapshot->styles["flex-shrink"] =
+                SerializableData(SerializableData::Impl::parse("0"));
+        }
+    }
+
     // Apply StyleDefaults before Yoga conversion to ensure complete default layout styles are available
     const auto& styleDefaults = StyleDefaults::getDefaults();
     for (const auto& pair : styleDefaults) {


### PR DESCRIPTION
## Description

List component could not scroll horizontally because child nodes were
shrinking to fit the container. For scroll-capable containers, child
nodes now default to `flex-shrink: 0`, allowing them to retain their
intrinsic size and enabling proper horizontal scrolling.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [ ] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [ ] Code compiles without errors on affected platform(s)
- [ ] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)