### PR TITLE
fix: Adapt the Button component for dark mode when using default configuration

### DIFF
--- a/core/src/surface/component_property_spec/agenui_component_spec_config.h
+++ b/core/src/surface/component_property_spec/agenui_component_spec_config.h
@@ -213,7 +213,7 @@ static const char* const kBaseComponentSpecConfig = R"JSON({
         "default": {
           "width": "auto",
           "height": "auto",
-          "background-color": "#FFFFFF",
+          "background-color": {"call": "token", "args": {"name": "Color_BG_L5"}},
           "border-radius": "16px",
           "border-width": "1px",
           "border-color": "rgba(0, 0, 0, 0.06)"

--- a/playground/harmony/entry/src/main/resources/rawfile/stories/A2UI Show/Button/updateComponents.json
+++ b/playground/harmony/entry/src/main/resources/rawfile/stories/A2UI Show/Button/updateComponents.json
@@ -39,8 +39,7 @@
         "styles": {
           "font-size": "32px",
           "line-height": "44px",
-          "text-align": "center",
-          "color": "#000000"
+          "text-align": "center"
         }
       }
     ]

--- a/playground/resource/stories/A2UI Show/Button/updateComponents.json
+++ b/playground/resource/stories/A2UI Show/Button/updateComponents.json
@@ -39,8 +39,7 @@
         "styles": {
           "font-size": "32px",
           "line-height": "44px",
-          "text-align": "center",
-          "color": "#000000"
+          "text-align": "center"
         }
       }
     ]


### PR DESCRIPTION
## Description
The Button component with default configuration still has a white background in dark mode, as shown in the figure below.
<img width="541" height="187" alt="image" src="https://github.com/user-attachments/assets/90f26e71-cb3f-4178-a99f-baec2def7088" />
Expected dark background (see below)
<img width="543" height="194" alt="image" src="https://github.com/user-attachments/assets/7a397518-cd25-4712-85b6-c33e77977cb2" />


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [x] Android
- [x] iOS
- [x] HarmonyOS
- [x] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [x] Code compiles without errors on affected platform(s)
- [x] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)