### PR TITLE
fix: Adapt the ChoicePicker component with default configuration for dark mode on HarmonyOS devices

### DIFF
--- a/core/src/surface/component_property_spec/agenui_component_spec_config.h
+++ b/core/src/surface/component_property_spec/agenui_component_spec_config.h
@@ -156,7 +156,8 @@ static const char* const kBaseComponentSpecConfig = R"JSON({
       "styles": {
         "default": {
           "orientation": "vertical",
-          "padding": "24px"
+          "padding": "24px",
+          "text-color": {"call": "token", "args": {"name": "Color_Black"}}
         }
       }
     },

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/measure/a2ui_platform_layout_bridge.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/measure/a2ui_platform_layout_bridge.cpp
@@ -70,7 +70,7 @@ static const char* g_component_styles = R"JSON({
     "checkbox-border-width": "3px",
     "checkbox-border-radius": "12px",
     "text-margin": "16px",
-    "text-color": "#000000",
+    "text-color": {"call": "token", "args": {"name": "Color_Black"}},
     "text-size": "32px",
     "choice-gap": "40px",
     "chip-padding-horizontal": "28px",

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/choicepicker_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/choicepicker_component.cpp
@@ -5,6 +5,7 @@
 #include "log/a2ui_capi_log.h"
 #include "a2ui/measure/a2ui_platform_layout_bridge.h"
 #include "a2ui/utils/a2ui_unit_utils.h"
+#include "surface/token_parser/agenui_token_parser.h"
 #include <nlohmann/json.hpp>
 
 #include <cstdlib>
@@ -571,10 +572,26 @@ float ChoicePickerComponent::getStyleDimension(const char* key, float fallbackVa
 }
 
 uint32_t ChoicePickerComponent::getStyleColor(const char* key, uint32_t fallbackValue) const {
-    if (!m_styleConfig.is_object() || !m_styleConfig.contains(key) || !m_styleConfig[key].is_string()) {
+    if (!m_styleConfig.is_object() || !m_styleConfig.contains(key)) {
         return fallbackValue;
     }
-    return parseColor(m_styleConfig[key].get<std::string>());
+    if (m_styleConfig[key].is_string()) {
+        return parseColor(m_styleConfig[key].get<std::string>());
+    } else if (m_styleConfig[key].is_object()) {
+        if (m_styleConfig[key].contains("call") && m_styleConfig[key]["call"].is_string()) {
+            std::string callType = m_styleConfig[key]["call"].get<std::string>();
+            if (callType == "token" && m_styleConfig[key].contains("args")) {
+                const auto& args = m_styleConfig[key]["args"];
+                if (args.contains("name") && args["name"].is_string()) {
+                    std::string tokenName = args["name"].get<std::string>();
+                    std::string resolvedColor = agenui::TokenParser::getInstance().resolve(tokenName);
+                    HM_LOGI("Resolved FunctionCall token '%s' to '%s'", tokenName.c_str(), resolvedColor.c_str());
+                    return parseColor(resolvedColor);
+                }
+            }
+        }
+    }
+    return fallbackValue;
 }
 
 std::string ChoicePickerComponent::getStyleString(const char* key, const std::string& fallbackValue) const {


### PR DESCRIPTION
## Description
The ChoicePicker component still has black text color when using default configuration, as shown in the figure below.
<img width="638" height="352" alt="image" src="https://github.com/user-attachments/assets/a8516632-6c25-4a9d-b27c-4352a27d5d37" />
Expected light color (see below)
<img width="592" height="386" alt="image" src="https://github.com/user-attachments/assets/327ac1ea-bc50-46bb-a15d-39171994419d" />


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [x] HarmonyOS
- [x] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [x] Code compiles without errors on affected platform(s)
- [x] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)