### PR TITLE
fix(Harmony): Resolve the problem that the layout is not recalculated when the window dimensions change

### DIFF
--- a/platforms/harmony/agenui/src/main/ets/agenui/AGenUIContainer.ets
+++ b/platforms/harmony/agenui/src/main/ets/agenui/AGenUIContainer.ets
@@ -58,9 +58,10 @@ export struct AGenUIContainer {
     .width('100%')
     .onSizeChange((oldValue: SizeOptions, newValue: SizeOptions) => {
       const newWidth = Math.round(newValue.width as number);
+      const oldWidth = Math.round(oldValue.width as number);
 
       // Notify the native layer only once after the first valid width is available.
-      if (this.widthNotified || newWidth <= 0) {
+      if ((this.widthNotified && newWidth === oldWidth) || newWidth <= 0) {
         return;
       }
 


### PR DESCRIPTION
## Description
- When a foldable device is folded from its expanded state, the page content is truncated
<img width="1700" height="1104" alt="9A939EBB-07C5-40A4-AEB4-9D80A7AB70D8(2)" src="https://github.com/user-attachments/assets/cb30ea0d-a815-4313-b3c3-3771f3d48451" />
<img width="530" height="1096" alt="9A939EBB-07C5-40A4-AEB4-9D80A7AB70D8(4)" src="https://github.com/user-attachments/assets/077ebe7b-315d-416d-aa2a-230d10c6ab16" />

- When a foldable device is unfolded from its folded state, excessive empty space is displayed on the page
<img width="528" height="1116" alt="9A939EBB-07C5-40A4-AEB4-9D80A7AB70D8(1)" src="https://github.com/user-attachments/assets/89c75173-64f7-4083-accb-3af5823e7d19" />
<img width="1700" height="1132" alt="9A939EBB-07C5-40A4-AEB4-9D80A7AB70D8(6)" src="https://github.com/user-attachments/assets/06f948d4-3a3c-4b6a-890b-bd7346def9ef" />

- When the screen is rotated, the page may experience content truncation or display excessive empty space
<img width="808" height="1118" alt="9A939EBB-07C5-40A4-AEB4-9D80A7AB70D8" src="https://github.com/user-attachments/assets/4d9dcf35-6609-45bb-90fa-b3e9094d4268" />
<img width="1164" height="766" alt="9A939EBB-07C5-40A4-AEB4-9D80A7AB70D8(5)" src="https://github.com/user-attachments/assets/867107ea-3a64-449f-8987-fba22f17cead" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [x] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [x] Code compiles without errors on affected platform(s)
- [x] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)