### PR TITLE
fix(Harmony): Adapt the Table component for dark mode when using default configuration

### DIFF
--- a/core/src/surface/component_property_spec/agenui_component_spec_config.h
+++ b/core/src/surface/component_property_spec/agenui_component_spec_config.h
@@ -168,7 +168,10 @@ static const char* const kBaseComponentSpecConfig = R"JSON({
         "default": {
             "border-width": "1px",
             "border-radius": "16px",
-            "border-color": "#E1E4E9"
+            "border-color": "#E1E4E9",
+            "header-bg-color": {"call": "token", "args": {"name": "Color_Ink_L2"}},
+            "body-bg-color-even": {"call": "token", "args": {"name": "Color_White"}},
+            "body-bg-color-odd": {"call": "token", "args": {"name": "Color_BG_L1"}}
         }
       }
     },

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/table_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/table_component.cpp
@@ -105,6 +105,21 @@ void TableComponent::parseStyles(const nlohmann::json& properties) {
         }
         HM_LOGI("border-radius from properties.styles: %.1f (not implemented yet)", borderRadius);
     }
+    
+    if (styles.find("header-bg-color") != styles.end() && styles["header-bg-color"].is_string()) {
+        m_headerBackground = parseColor(styles["header-bg-color"].get<std::string>());
+        HM_LOGI("Header-bg-color from styles: 0x%08X", m_headerBackground);
+    }
+
+    if (styles.find("body-bg-color-even") != styles.end() && styles["body-bg-color-even"].is_string()) {
+        m_bodyBgColorEven = parseColor(styles["body-bg-color-even"].get<std::string>());
+        HM_LOGI("Body-bg-color-even from styles: 0x%08X", m_bodyBgColorEven);
+    }
+
+    if (styles.find("body-bg-color-odd") != styles.end() && styles["body-bg-color-odd"].is_string()) {
+        m_bodyBgColorOdd = parseColor(styles["body-bg-color-odd"].get<std::string>());
+        HM_LOGI("Body-bg-color-odd from styles: 0x%08X", m_bodyBgColorOdd);
+    }
 }
 
 void TableComponent::loadComponentStyles() {


### PR DESCRIPTION
## Description
The Table component with default configuration still has a light background in dark mode, as shown in the figure below.
<img width="475" height="419" alt="image" src="https://github.com/user-attachments/assets/187372fb-d386-4563-af96-e053665d8dcb" />
Expected dark background (see below)
<img width="480" height="424" alt="image" src="https://github.com/user-attachments/assets/e7b2e5ed-921f-4370-8bbe-c7198eb84c92" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [x] HarmonyOS
- [x] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [x] Code compiles without errors on affected platform(s)
- [x] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)