### PR TITLE
fix(Harmony): Adapt the Tabs component for dark mode when using default configuration

### DIFF
--- a/core/src/surface/component_property_spec/agenui_component_spec_config.h
+++ b/core/src/surface/component_property_spec/agenui_component_spec_config.h
@@ -161,6 +161,14 @@ static const char* const kBaseComponentSpecConfig = R"JSON({
         }
       }
     },
+    "Tabs": {
+      "styles": {
+        "default": {
+          "tab-font-color": {"call": "token", "args": {"name": "Color_Black"}},
+          "tab-font-color-selected": {"call": "token", "args": {"name": "Color_Text_Brand"}}
+        }
+      }
+    },
     "Table": {
       "headers": {"default": []},
       "rows": {"default": []},

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/measure/a2ui_platform_layout_bridge.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/measure/a2ui_platform_layout_bridge.cpp
@@ -26,8 +26,8 @@ static const char* g_component_styles = R"JSON({
     "indicator-radius": "4px",
     "tab-font-size": "32px",
     "tab-font-size-selected": "32px",
-    "tab-font-color": "#000000",
-    "tab-font-color-selected": "#2273F7",
+    "tab-font-color": {"call": "token", "args": {"name": "Color_Black"}},
+    "tab-font-color-selected": {"call": "token", "args": {"name": "Color_Text_Brand"}},
     "tab-font-weight": "normal",
     "tab-font-weight-selected": "bold"
   },

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_component.cpp
@@ -20,6 +20,7 @@
 #include "a2ui/bridge/image_loader_bridge.h"
 #include "a2ui/render/gradient_applier.h"
 #include "style_parser/agenui_color_parser.h"
+#include "surface/token_parser/agenui_token_parser.h"
 
 namespace a2ui {
 
@@ -490,6 +491,26 @@ uint32_t A2UIComponent::parseColor(const std::string& colorStr) {
     return cv.solidColor;
 }
 
+uint32_t A2UIComponent::parseColorWithToken(const nlohmann::json& colorValue, uint32_t fallbackValue) {
+    if (colorValue.is_string()) {
+        return parseColor(colorValue.get<std::string>());
+    } else if (colorValue.is_object()) {
+        if (colorValue.contains("call") && colorValue["call"].is_string()) {
+            std::string callType = colorValue["call"].get<std::string>();
+            if (callType == "token" && colorValue.contains("args")) {
+                const auto& args = colorValue["args"];
+                if (args.contains("name") && args["name"].is_string()) {
+                    std::string tokenName = args["name"].get<std::string>();
+                    std::string resolvedColor = agenui::TokenParser::getInstance().resolve(tokenName);
+                    HM_LOGI("Resolved FunctionCall token '%s' to '%s'", tokenName.c_str(), resolvedColor.c_str());
+                    return parseColor(resolvedColor);
+                }
+            }
+        }
+    }
+
+    return fallbackValue;
+}
 
 /**
  * Extract the raw URL from a CSS url(...) value.

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_component.h
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_component.h
@@ -204,6 +204,17 @@ protected:
      */
     static uint32_t parseColor(const std::string& colorStr);
 
+    /**
+     * Parse a color value that may be a FunctionCall token reference.
+     * Supported formats:
+     *   1. String: Direct color value (e.g., "#FFFFFF", "#RRGGBBAA")
+     *      -> Parsed directly by parseColor()
+     *   2. JSON object with {"call": "token", "args": {"name": "TokenName"}}
+     *      -> Extracts token name, resolves via TokenParser, then parsed by parseColor()
+     * Return fallbackValue on parse failure or empty string.
+     */
+    static uint32_t parseColorWithToken(const nlohmann::json& colorValue, uint32_t fallbackValue);
+
 public:
     float getX() const { return m_x; }
     float getY() const { return m_y; }

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/choicepicker_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/choicepicker_component.cpp
@@ -5,7 +5,6 @@
 #include "log/a2ui_capi_log.h"
 #include "a2ui/measure/a2ui_platform_layout_bridge.h"
 #include "a2ui/utils/a2ui_unit_utils.h"
-#include "surface/token_parser/agenui_token_parser.h"
 #include <nlohmann/json.hpp>
 
 #include <cstdlib>
@@ -575,23 +574,7 @@ uint32_t ChoicePickerComponent::getStyleColor(const char* key, uint32_t fallback
     if (!m_styleConfig.is_object() || !m_styleConfig.contains(key)) {
         return fallbackValue;
     }
-    if (m_styleConfig[key].is_string()) {
-        return parseColor(m_styleConfig[key].get<std::string>());
-    } else if (m_styleConfig[key].is_object()) {
-        if (m_styleConfig[key].contains("call") && m_styleConfig[key]["call"].is_string()) {
-            std::string callType = m_styleConfig[key]["call"].get<std::string>();
-            if (callType == "token" && m_styleConfig[key].contains("args")) {
-                const auto& args = m_styleConfig[key]["args"];
-                if (args.contains("name") && args["name"].is_string()) {
-                    std::string tokenName = args["name"].get<std::string>();
-                    std::string resolvedColor = agenui::TokenParser::getInstance().resolve(tokenName);
-                    HM_LOGI("Resolved FunctionCall token '%s' to '%s'", tokenName.c_str(), resolvedColor.c_str());
-                    return parseColor(resolvedColor);
-                }
-            }
-        }
-    }
-    return fallbackValue;
+    return parseColorWithToken(m_styleConfig[key], fallbackValue);
 }
 
 std::string ChoicePickerComponent::getStyleString(const char* key, const std::string& fallbackValue) const {

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/tabs_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/tabs_component.cpp
@@ -141,6 +141,10 @@ void TabsComponent::onUpdateProperties(const nlohmann::json& properties) {
     if (properties.contains("tabs") && properties["tabs"].is_array()) {
         buildTabBar(properties);
     }
+    
+    if (properties.contains("styles") && properties["styles"].is_object()) {
+        updateTabStyles();
+    }
 
     HM_LOGI( "id=%s, selectedIndex=%d",
                 m_id.c_str(), m_selectedIndex);
@@ -371,11 +375,11 @@ void TabsComponent::updateTabStyles() {
 
     const nlohmann::json tabsStyles = getComponentStylesFor("Tabs");
     if (tabsStyles.is_object()) {
-        if (tabsStyles.contains("tab-font-color") && tabsStyles["tab-font-color"].is_string()) {
-            fontColor = parseColor(tabsStyles["tab-font-color"].get<std::string>());
+        if (tabsStyles.contains("tab-font-color")) {
+            fontColor = parseColorWithToken(tabsStyles["tab-font-color"], fontColor);
         }
-        if (tabsStyles.contains("tab-font-color-selected") && tabsStyles["tab-font-color-selected"].is_string()) {
-            fontColorSelected = parseColor(tabsStyles["tab-font-color-selected"].get<std::string>());
+        if (tabsStyles.contains("tab-font-color-selected")) {
+            fontColorSelected = parseColorWithToken(tabsStyles["tab-font-color-selected"], fontColorSelected);
         }
 
         auto readFontSize = [&tabsStyles](const char* key, float& out) {


### PR DESCRIPTION
## Description
When using default configuration, the unselected tab titles of the Tabs component remain black in dark mode.
<img width="667" height="251" alt="image" src="https://github.com/user-attachments/assets/ce9c31fb-8097-4a3e-8f17-a18f0dbc1de3" />
Expected behavior: They should display in light color.
<img width="670" height="264" alt="image" src="https://github.com/user-attachments/assets/79861e0e-5164-42e7-9d89-e139b41090d1" />


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [x] HarmonyOS
- [x] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [x] Code compiles without errors on affected platform(s)
- [x] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)