### PR TITLE
fix(android): resolve first-build failure with --publish-local and su…

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ All build scripts live in the `scripts/` directory. The C++ engine in `core/` is
 # Publish to local Maven (~/.m2)
 ./scripts/android/build.sh --publish-local
 
+# Publish debug AAR to local Maven
+./scripts/android/build.sh --debug --publish-local
+
 # Publish to remote Maven (requires MAVEN_URL / MAVEN_USERNAME / MAVEN_PASSWORD env vars)
 ./scripts/android/build.sh --publish-maven
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -217,6 +217,9 @@ cp -r AGenUI/skills/a2ui-generation ~/.claude/skills/
 # 发布到本地 Maven（~/.m2）
 ./scripts/android/build.sh --publish-local
 
+# 发布 debug AAR 到本地 Maven
+./scripts/android/build.sh --debug --publish-local
+
 # 发布到远程 Maven（需 MAVEN_URL / MAVEN_USERNAME / MAVEN_PASSWORD 环境变量）
 ./scripts/android/build.sh --publish-maven
 

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -169,54 +169,65 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            release(MavenPublication) {
-                // Allow -PmavenVersion / -PmavenGroupId / -PmavenArtifactId to override defaults.
-                // -PmavenAarPath overrides the AAR file path. Used by external wrappers that
-                // publish a previously-built sidecar AAR (e.g. the <name>-symbols.aar from
-                // --with-symbols) through this same publication with a suffixed version,
-                // without re-running assembleRelease.
-                def pubGroupId = project.hasProperty('mavenGroupId') ? project.property('mavenGroupId') : SDK_GROUP_ID
-                def pubArtifactId = project.hasProperty('mavenArtifactId') ? project.property('mavenArtifactId') : SDK_ARTIFACT_ID
-                def pubVersion = project.hasProperty('mavenVersion') ? project.property('mavenVersion') : SDK_VERSION
-                def pubAarPath = project.hasProperty('mavenAarPath') ? project.property('mavenAarPath') : "${buildDir}/outputs/aar/${project.name}-release.aar"
+            ['release', 'debug'].each { variant ->
+                def capVariant = variant.capitalize()
 
-                groupId    = pubGroupId
-                artifactId = pubArtifactId
-                version    = pubVersion
+                create(variant, MavenPublication) {
+                    // Allow -PmavenVersion / -PmavenGroupId / -PmavenArtifactId to override defaults.
+                    // -PmavenAarPath overrides the AAR file path (release only). Used by external
+                    // wrappers that publish a previously-built sidecar AAR (e.g. the
+                    // <name>-symbols.aar from --with-symbols) through this same publication with
+                    // a suffixed version, without re-running assembleRelease.
+                    def pubGroupId = project.hasProperty('mavenGroupId') ? project.property('mavenGroupId') : SDK_GROUP_ID
+                    def pubArtifactId = project.hasProperty('mavenArtifactId') ? project.property('mavenArtifactId') : SDK_ARTIFACT_ID
+                    def pubVersion = project.hasProperty('mavenVersion') ? project.property('mavenVersion') : SDK_VERSION
+                    def defaultAarPath = "${buildDir}/outputs/aar/${project.name}-${variant}.aar"
+                    def pubAarPath = (variant == 'release' && project.hasProperty('mavenAarPath'))
+                            ? project.property('mavenAarPath') : defaultAarPath
 
-                if (project.hasProperty('mavenVersion')) {
-                    logger.lifecycle("[maven] Publishing with version: ${pubVersion} (groupId=${pubGroupId}, artifactId=${pubArtifactId}, aar=${pubAarPath})")
-                }
+                    groupId    = pubGroupId
+                    artifactId = pubArtifactId
+                    version    = pubVersion
 
-                def normalAar = file(pubAarPath)
-                artifact(normalAar)
+                    if (project.hasProperty('mavenVersion')) {
+                        logger.lifecycle("[maven] Publishing ${variant} with version: ${pubVersion} (groupId=${pubGroupId}, artifactId=${pubArtifactId}, aar=${pubAarPath})")
+                    }
 
-                pom {
-                    name        = 'AGenUI'
-                    description = 'A Native Renderer for A2UI - AGen UI SDK.'
-                    url         = 'https://github.com/AGenUI/AGenUI-Client-Android'
-
-                    licenses {
-                        license {
-                            name = 'Apache-2.0'
-                            url  = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    def normalAar = file(pubAarPath)
+                    if (variant == 'release' && project.hasProperty('mavenAarPath')) {
+                        artifact(normalAar)
+                    } else {
+                        artifact(normalAar) {
+                            builtBy tasks.named("assemble${capVariant}")
                         }
                     }
 
-                    // Transitive dependency declarations
-                    withXml {
-                        def deps = asNode().appendNode('dependencies')
-                        configurations.releaseRuntimeClasspath
-                            .resolvedConfiguration
-                            .resolvedArtifacts
-                            .findAll { it.moduleVersion.id.group != project.group }
-                            .each { artifact ->
-                                def dep = deps.appendNode('dependency')
-                                dep.appendNode('groupId',    artifact.moduleVersion.id.group)
-                                dep.appendNode('artifactId', artifact.moduleVersion.id.name)
-                                dep.appendNode('version',    artifact.moduleVersion.id.version)
-                                dep.appendNode('scope',      'runtime')
+                    pom {
+                        name        = 'AGenUI'
+                        description = 'A Native Renderer for A2UI - AGen UI SDK.'
+                        url         = 'https://github.com/AGenUI/AGenUI-Client-Android'
+
+                        licenses {
+                            license {
+                                name = 'Apache-2.0'
+                                url  = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                             }
+                        }
+
+                        withXml {
+                            def deps = asNode().appendNode('dependencies')
+                            configurations["${variant}RuntimeClasspath"]
+                                .resolvedConfiguration
+                                .resolvedArtifacts
+                                .findAll { it.moduleVersion.id.group != project.group }
+                                .each { resolvedArtifact ->
+                                    def dep = deps.appendNode('dependency')
+                                    dep.appendNode('groupId',    resolvedArtifact.moduleVersion.id.group)
+                                    dep.appendNode('artifactId', resolvedArtifact.moduleVersion.id.name)
+                                    dep.appendNode('version',    resolvedArtifact.moduleVersion.id.version)
+                                    dep.appendNode('scope',      'runtime')
+                                }
+                        }
                     }
                 }
             }

--- a/scripts/android/build.sh
+++ b/scripts/android/build.sh
@@ -17,8 +17,11 @@ set -euo pipefail
 #                           Other common values:
 #                             assembleDebug
 #                             publishReleasePublicationToLocalMavenRepository
-#   --debug                 Equivalent to --task assembleDebug
-#   --publish-local         Equivalent to --task publishReleasePublicationToLocalMavenRepository
+#   --debug                 Build the debug variant (default: release).
+#                           Can be combined with --publish-local.
+#   --publish-local         Publish AAR to local Maven (~/.m2). Respects --debug:
+#                           builds and publishes the debug variant if set,
+#                           otherwise the release variant.
 #   --publish-maven         Publish AAR to remote Maven repository.
 #                           Requires MAVEN_URL / MAVEN_USERNAME / MAVEN_PASSWORD env vars.
 #                           Optionally set AGENUI_MAVEN_GROUP / AGENUI_MAVEN_ARTIFACT env vars
@@ -39,6 +42,7 @@ set -euo pipefail
 #   ./scripts/android/build.sh                       # default assembleRelease
 #   ./scripts/android/build.sh --debug --clean
 #   ./scripts/android/build.sh --publish-local
+#   ./scripts/android/build.sh --debug --publish-local  # publish debug AAR to local Maven
 #   ./scripts/android/build.sh --yoga-prebuilt ./yoga_prebuilt/android/arm64-v8a/Test
 # ============================================================================
 
@@ -49,7 +53,8 @@ source "${SCRIPT_DIR}/../common/_common.sh"
 source "${SCRIPT_DIR}/../common/_build_id.sh"
 
 # -------------------- Defaults --------------------
-GRADLE_TASK="assembleRelease"
+GRADLE_TASK=""
+BUILD_VARIANT="release"
 DO_CLEAN=false
 YOGA_PREBUILT_DIR=""
 YOGA_INCLUDE_IN_AAR=""
@@ -60,15 +65,17 @@ ANDROID_PROJECT_ROOT="${PLATFORMS_DIR}/android"
 
 # -------------------- Argument parsing --------------------
 show_help() {
-    sed -n '5,42p' "$0" | sed -E 's/^#( |$)//'
+    sed -n '5,46p' "$0" | sed -E 's/^#( |$)//'
     exit 0
 }
+
+PUBLISH_LOCAL=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --task)            GRADLE_TASK="$2"; shift 2 ;;
-        --debug)           GRADLE_TASK="assembleDebug"; shift ;;
-        --publish-local)   GRADLE_TASK="publishReleasePublicationToLocalMavenRepository"; shift ;;
+        --debug)           BUILD_VARIANT="debug"; shift ;;
+        --publish-local)   PUBLISH_LOCAL=true; shift ;;
         --publish-maven)   PUBLISH_MAVEN=true; shift ;;
         --yoga-prebuilt)   YOGA_PREBUILT_DIR="$2"; shift 2 ;;
         --no-yoga-in-aar)  YOGA_INCLUDE_IN_AAR="false"; shift ;;
@@ -78,6 +85,20 @@ while [[ $# -gt 0 ]]; do
         *)                 error "Unknown argument: $1" ;;
     esac
 done
+
+# -------------------- Resolve GRADLE_TASK --------------------
+CAP_VARIANT="$(tr '[:lower:]' '[:upper:]' <<< "${BUILD_VARIANT:0:1}")${BUILD_VARIANT:1}"
+if [[ "$PUBLISH_LOCAL" == true ]]; then
+    if [[ -n "$GRADLE_TASK" ]]; then
+        error "--publish-local cannot be combined with --task"
+    fi
+    GRADLE_TASK="publish${CAP_VARIANT}PublicationToLocalMavenRepository"
+elif [[ -z "$GRADLE_TASK" ]]; then
+    GRADLE_TASK="assemble${CAP_VARIANT}"
+fi
+if [[ "$PUBLISH_MAVEN" == true && "$BUILD_VARIANT" != "release" ]]; then
+    error "--publish-maven only supports the release variant. Remove --debug and try again."
+fi
 
 [[ -d "$ANDROID_PROJECT_ROOT" ]] || error "Android project directory not found: ${ANDROID_PROJECT_ROOT}"
 [[ -x "${ANDROID_PROJECT_ROOT}/gradlew" ]] || error "Executable gradlew not found: ${ANDROID_PROJECT_ROOT}/gradlew"


### PR DESCRIPTION
## Description

Fix the first-build failure when running `./scripts/android/build.sh --publish-local`, and add variant-aware local Maven publishing support.

**Root cause:** The Maven publication in `build.gradle` used a bare `artifact(file)` declaration without telling Gradle which task produces the AAR. On a clean/first build, `publishReleasePublicationToLocalMavenRepository` ran without triggering `assembleRelease`, so the AAR file didn't exist and the build failed.

**Changes:**
- Add `builtBy` on the artifact declaration so publish tasks automatically depend on the corresponding assemble task
- Introduce `BUILD_VARIANT` in `build.sh` so `--debug` and `--publish-local` can be combined â `--debug --publish-local` now correctly builds and publishes the debug AAR
- Add a `debug` MavenPublication alongside `release` in `build.gradle`
- Reject `--debug --publish-maven` early (before building) since remote publishing only supports the release variant
- Update `--help` text, script examples, and both README files

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [x] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [x] Android
- [ ] iOS
- [ ] HarmonyOS
- [ ] C++ Core Engine
- [x] Documentation / CI

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [x] Code compiles without errors on affected platform(s)
- [x] I have tested on relevant device(s) or simulator(s)
- [x] Documentation updated (if applicable)