### PR TITLE
Add limit to image variant

### DIFF
--- a/core/src/surface/component_property_spec/agenui_component_spec_config.h
+++ b/core/src/surface/component_property_spec/agenui_component_spec_config.h
@@ -77,9 +77,9 @@ static const char* const kBaseComponentSpecConfig = R"JSON({
         "enum": {
           "icon": {"styles": {"width": "48px", "height": "48px", "border-radius": "0px"}},
           "avatar": {"styles": {"width": "88px", "height": "88px", "border-radius": "44px"}},
-          "smallFeature": {"styles": {"width": "100%", "aspect-ratio": "4 / 3", "border-radius": "8px"}},
-          "mediumFeature": {"styles": {"width": "100%", "aspect-ratio": "3 / 2","border-radius": "16px"}},
-          "largeFeature": {"styles": {"width": "100%", "aspect-ratio": "16 / 9","border-radius": "24px"}},
+          "smallFeature": {"styles": {"max-width": "100", "width": "100%", "aspect-ratio": "4 / 3", "border-radius": "8px"}},
+          "mediumFeature": {"styles": {"max-width": "300", "width": "100%", "aspect-ratio": "3 / 2","border-radius": "16px"}},
+          "largeFeature": {"styles": {"max-width": "400", "width": "100%", "aspect-ratio": "16 / 9","border-radius": "24px"}},
           "header": {"styles": {"width": "100%", "aspect-ratio": "16 / 9","border-radius": "0px"}}
         }
       },


### PR DESCRIPTION
Accoding to Implementation Guide, add size limit to image's variant properties

## Description

As [Implementation [Guide]](https://a2ui.org/specification/v0.9.1-basic-catalog-implementation-guide/#image) suggested, add max-width limit.

## Type of Change

- [ ] Bug fix
- [ X ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ X ] Android
- [ X ] iOS
- [ X ] HarmonyOS
- [ X ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [X] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [X] Code compiles without errors on affected platform(s)
- [X] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)