### PR TITLE
fix(harmony): support number type for Text component's 'text' field

### DIFF
--- a/platforms/harmony/agenui/src/main/cpp/a2ui/measure/text_component_measurement.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/measure/text_component_measurement.cpp
@@ -81,8 +81,13 @@ bool TextComponentMeasurement::buildParam(const nlohmann::json& j,
 
     // ---- Extract text content (attributes flattened at root level: text / label) ----
     // stringify() flattens attributes to root level without "attrs" wrapper
-    if (j.contains("text") && j["text"].is_string()) {
-        outText = j["text"].get<std::string>();
+    if (j.contains("text")) {
+        const auto& textVal = j["text"];
+        if (textVal.is_string()) {
+            outText = textVal.get<std::string>();
+        } else if (textVal.is_number()) {
+            outText = textVal.dump();
+        }
     } else if (j.contains("label") && j["label"].is_string()) {
         outText = j["label"].get<std::string>();
     }

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/text_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/text_component.cpp
@@ -119,6 +119,8 @@ void TextComponent::applyTextContent(const nlohmann::json& properties) {
 
         if (chunkValue.is_string()) {
             chunkContent = chunkValue.get<std::string>();
+        } else if (chunkValue.is_number()) {
+            chunkContent = chunkValue.dump();
         } else if (chunkValue.is_object()) {
             auto litIt = chunkValue.find("literalString");
             if (litIt != chunkValue.end() && litIt->is_string()) {
@@ -148,6 +150,10 @@ void TextComponent::applyTextContent(const nlohmann::json& properties) {
         // Format 2: {"text": "Hello"}
         else if (textValue.is_string()) {
             textContent = textValue.get<std::string>();
+        }
+        // Format 3: {"text": 1} — number type, convert to string
+        else if (textValue.is_number()) {
+            textContent = textValue.dump();
         }
 
         if (!textContent.empty()) {


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [x] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [ ] Code compiles without errors on affected platform(s)
- [ ] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)