### PR TITLE
fix(android):  #103

### DIFF
--- a/platforms/android/src/main/java/com/amap/agenui/render/component/impl/TextComponent.java
+++ b/platforms/android/src/main/java/com/amap/agenui/render/component/impl/TextComponent.java
@@ -132,6 +132,10 @@ public class TextComponent extends A2UIComponent {
             }
         }
 
+        if(textValue instanceof Double && (Double) textValue % 1.0 == 0.0) {
+            return String.valueOf(((Double) textValue).intValue());
+        }
+
         // Direct string
         return String.valueOf(textValue);
     }


### PR DESCRIPTION
修正gson转换默认double导致文字组件错误显示省略号的问题 #103 

## Description

由于gson转换将默认类型设置为Double，导致整数值错误转换后显示错乱。

由于此问题仅影响Text组件，故采用小补丁修正。不对gson转换部分做进一步改动。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [x] Android
- [ ] iOS
- [ ] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [x] Code compiles without errors on affected platform(s)
- [x] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)