### PR TITLE
fix(ios): keep background gradient below child content (ISSUE-004)

### DIFF
--- a/platforms/ios/AGenUI/Classes/Render/Component/CSS/CSSPropertyApplier.swift
+++ b/platforms/ios/AGenUI/Classes/Render/Component/CSS/CSSPropertyApplier.swift
@@ -458,6 +458,15 @@ class CSSPropertyApplier {
         view.layer.shadowPath = nil
         view.layer.shouldRasterize = false
     }
+
+    /// Re-asserts an installed background gradient to the bottom of the sublayer
+    /// stack. Container components call this from `didAddSubview`: children are
+    /// mounted via `insertSubview(_:at:)` at explicit indices, which can push a
+    /// bare gradient sublayer above the child views and hide their content
+    /// (ISSUE-004). Solid `backgroundColor` is unaffected as it is not a sublayer.
+    @MainActor static func enforceGradientBottom(on view: UIView) {
+        BackgroundGradientHolder.moveToBack(on: view)
+    }
         
 
 
@@ -491,6 +500,14 @@ fileprivate enum BackgroundGradientHolder {
         objc_setAssociatedObject(view, &key, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
 
+    /// Force the installed gradient layer back to the bottom of its host's
+    /// sublayer stack (no-op when none is installed).
+    static func moveToBack(on view: UIView) {
+        if let state = objc_getAssociatedObject(view, &key) as? State {
+            state.enforceBottom()
+        }
+    }
+
     /// One per (view, gradient) installation. Holds the CAGradientLayer + KVO token.
     private final class State {
         private weak var view: UIView?
@@ -514,6 +531,17 @@ fileprivate enum BackgroundGradientHolder {
             observation = nil
             gradientLayer?.removeFromSuperlayer()
             gradientLayer = nil
+        }
+
+        /// Re-insert the gradient at sublayer index 0 if something (typically a
+        /// child `insertSubview(_:at:)`) has pushed it up the stack.
+        func enforceBottom() {
+            guard let view = view, let layer = gradientLayer else { return }
+            guard view.layer.sublayers?.first !== layer else { return }
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            view.layer.insertSublayer(layer, at: 0)
+            CATransaction.commit()
         }
 
         private func rebuild() {
@@ -546,6 +574,9 @@ fileprivate enum BackgroundGradientHolder {
                 existing.endPoint = fresh.endPoint
                 existing.cornerRadius = fresh.cornerRadius
                 existing.masksToBounds = fresh.masksToBounds
+                // Keep the gradient pinned to the bottom: a child mounted via
+                // insertSubview(_:at:) after the last rebuild may have displaced it.
+                view.layer.insertSublayer(existing, at: 0)
                 CATransaction.commit()
             } else {
                 CATransaction.begin()

--- a/platforms/ios/AGenUI/Classes/Render/Component/Component.swift
+++ b/platforms/ios/AGenUI/Classes/Render/Component/Component.swift
@@ -417,6 +417,15 @@ public enum MeasureMode: Int {
         updateProperties(self.properties)
     }
 
+    /// Keep an installed background gradient pinned below child content.
+    /// Children mount via `insertSubview(_:at:)` at explicit indices, which can
+    /// otherwise raise a bare gradient sublayer above them and hide their
+    /// content (ISSUE-004). Solid backgroundColor is unaffected.
+    open override func didAddSubview(_ subview: UIView) {
+        super.didAddSubview(subview)
+        CSSPropertyApplier.enforceGradientBottom(on: self)
+    }
+
 
     /// Recursively create views for all children and add them to the view hierarchy.
     private func createChildViews() {


### PR DESCRIPTION
UIView.backgroundColor cannot hold a gradient, so a CSS linear/radial/conic background is rendered via a bare CAGradientLayer sublayer. Container children are mounted with insertSubview(_:at:) at explicit indices, which can raise that sublayer above the child views and hide their content. Solid backgroundColor is unaffected since it is not a sublayer.

- CSSPropertyApplier: re-pin the gradient to sublayer index 0 on every rebuild; add BackgroundGradientHolder.moveToBack / State.enforceBottom and expose CSSPropertyApplier.enforceGradientBottom.

- Component: override didAddSubview to push the installed gradient back to the bottom after each child mount.

Android (View.setBackground) and Harmony (NODE_LINEAR_GRADIENT node attribute) use the framework background slot and are not affected.

## Description

<!-- Brief description of what this PR does and why -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [x] iOS
- [ ] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [ ] Code compiles without errors on affected platform(s)
- [ ] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)