### PR TITLE
feat: dashed underline support & rendering fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **List Item Appear Event & First Render Tracking**: Exposed list item appear event and first-render trackInfo to the integration layer for analytics and performance monitoring.
 - **Padding Parsing API**: Opened the padding parsing interface for external use, allowing integrators to access parsed padding values directly.
 - **linear-gradient Background Support**: Text, Button, List, Checkbox, Divider, and TextField components now support `linear-gradient` backgrounds via a unified base class method.
+- **Dashed Underline Support**: Added custom dashed underline style on iOS, Android, and HarmonyOS via `text-decoration` properties.
 
 ### Bug Fixes
 
@@ -19,12 +20,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - (iOS) Fixed shadow rendering too light — set `shadowOpacity` to `1.0` to prevent alpha being multiplied twice.
 - (iOS) Fixed `Surface.updateSize()` recursive layout notification causing stack overflow crash.
 - (iOS) Fixed `TabsComponent.addChild` closure strongly referencing child components, causing permanent memory leak.
-- (iOS) Fixed concurrent `ImageLoader` registration causing ARC reference count race crash.
-- (iOS) Fixed concurrent Function registration/deregistration causing Swift `Dictionary` race crash.
+- (iOS) Fixed concurrent `ImageLoader` registration causing ARC reference count race crash (#83354930).
+- (iOS) Fixed concurrent Function registration/deregistration causing Swift `Dictionary` race crash (#83354917).
 - (Android) Fixed Image with explicit `0px` being overridden by intrinsic image size, causing layout jitter.
-- (Android) Fixed strikethrough position error and improved line-height handling logic.
-- (HarmonyOS) Fixed Row child element overlap and vertical centering anomaly.
+- (Android) Fixed strikethrough position error and improved line-height handling logic (#83884229).
+- (HarmonyOS) Fixed Row child element overlap and vertical centering anomaly (#83823723).
 - (HarmonyOS) Fixed API 17 crash by replacing `OH_ArkUI_PostFrameCallback` with `dlsym` wrapper.
+- (All) Optimized large image loading to reduce UI jank.
+- (All) Fixed underline calculation for multi-line text and `thickness` unit conversion.
+- (iOS) Fixed strikethrough shorthand syntax not working.
+- (All) Fixed image crop size not multiplied by screen density.
+- (All) Fixed horizontal List unable to dynamically append child elements.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ English | [中文](README.zh-CN.md)
 - **List Item Appear Event & First Render Tracking**: Exposed list item appear event and first-render trackInfo to the integration layer for analytics and performance monitoring.
 - **Padding Parsing API**: Opened the padding parsing interface for external use, allowing integrators to access parsed padding values directly.
 - **linear-gradient Background Support**: Text, Button, List, Checkbox, Divider, and TextField components now support `linear-gradient` backgrounds via a unified base class method.
+- **Dashed Underline Support**: Added custom dashed underline style on iOS, Android, and HarmonyOS via `text-decoration` properties.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,6 +30,7 @@
 - **List Item 出现事件 & 首屏渲染埋点**：向集成层透出 list item appear 事件和 first-render trackInfo，用于数据分析和性能监控。
 - **Padding 解析接口开放**：开放 padding 解析接口，集成方可直接获取解析后的 padding 值。
 - **linear-gradient 渐变背景支持**：Text、Button、List、Checkbox、Divider、TextField 组件的 background-color 统一使用基类方法处理，支持 `linear-gradient` 渐变色。
+- **虚线下划线支持**：在 iOS、Android 和鸿蒙端新增自定义虚线下划线样式，通过 `text-decoration` 属性控制。
 
 ---
 

--- a/core/src/surface/component_property_spec/agenui_component_spec_config.h
+++ b/core/src/surface/component_property_spec/agenui_component_spec_config.h
@@ -183,13 +183,6 @@ static const char* const kBaseComponentSpecConfig = R"JSON({
         }
       }
     },
-    "Markdown": {
-      "styles": {
-        "default": {
-            "margin-bottom": "24px"
-        }
-      }
-    },
     "List": {
       "styles": {
         "default": {

--- a/platforms/android/src/main/java/com/amap/agenui/render/component/A2UIComponent.java
+++ b/platforms/android/src/main/java/com/amap/agenui/render/component/A2UIComponent.java
@@ -1,6 +1,7 @@
 package com.amap.agenui.render.component;
 
 import android.content.Context;
+import android.graphics.Rect;
 import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
@@ -1091,6 +1092,25 @@ public abstract class A2UIComponent {
         params.height = layoutState.heightPx;
         params.leftMargin = layoutState.xPx;
         params.topMargin = layoutState.yPx;
+
+        // Root node has no Yoga parent to consume its margin.
+        // Yoga's getLayoutLeft/Top already include margin-left/top in the
+        // position (see YGNode::setPosition), so leftMargin/topMargin above
+        // are correct. But margin-bottom/right are not reflected in either
+        // position or width/height, so set them explicitly on LayoutParams.
+        if ("root".equals(getId())) {
+            Map<String, Object> styles = extractStyles(properties);
+            if (styles != null) {
+                Context ctx = targetView.getContext();
+                Rect marginPx = StyleHelper.resolveCSSMarginPx(styles, ctx);
+                if (marginPx != null) {
+                    // top/left already in Yoga position (xPx/yPx), only set bottom/right
+                    params.bottomMargin = marginPx.bottom;
+                    params.rightMargin = marginPx.right;
+                }
+            }
+        }
+
         targetView.setLayoutParams(params);
         targetView.setZ(layoutState.zIndex);
     }

--- a/platforms/android/src/main/java/com/amap/agenui/render/component/impl/TextComponent.java
+++ b/platforms/android/src/main/java/com/amap/agenui/render/component/impl/TextComponent.java
@@ -64,7 +64,7 @@ public class TextComponent extends A2UIComponent {
         if (this.context == null) {
             this.context = context;
         }
-        textView = new A2UITextView(context);
+        textView = new TextView(context);
         textView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
 
         // ⚠️ Important: apply initial properties

--- a/platforms/android/src/main/java/com/amap/agenui/render/component/impl/list/YogaLayoutManager.java
+++ b/platforms/android/src/main/java/com/amap/agenui/render/component/impl/list/YogaLayoutManager.java
@@ -284,16 +284,22 @@ public class YogaLayoutManager extends RecyclerView.LayoutManager {
         int n = Math.min(itemCount, frameCount);
         for (int i = 0; i < n; i++) {
             Frame f = frames.get(i);
-            if (f.isEmpty()) continue;
             // Skip GONE children (mirrors YogaAbsoluteLayout).
             if (isGone(f.child)) continue;
 
             int width = f.rect.width();
             int height = effectiveFrameHeight(f);
             // Viewport intersection uses the effective (wrap-resolved) rect.
-            Rect frameRect = new Rect(f.rect.left, f.rect.top,
-                    f.rect.left + width, f.rect.top + height);
-            if (!Rect.intersects(frameRect, viewport)) continue;
+            // Zero-size frames (Yoga flex values pending) fall back to a
+            // point-in-viewport check using x,y position, so that off-screen
+            // items remain lazy while visible ones get views created.
+            if (width > 0 && height > 0) {
+                Rect frameRect = new Rect(f.rect.left, f.rect.top,
+                        f.rect.left + width, f.rect.top + height);
+                if (!Rect.intersects(frameRect, viewport)) continue;
+            } else {
+                if (!viewport.contains(f.rect.left, f.rect.top)) continue;
+            }
 
             View v = recycler.getViewForPosition(i);
             addView(v);
@@ -478,9 +484,6 @@ public class YogaLayoutManager extends RecyclerView.LayoutManager {
         int h = readIntStyle(styles.get("height"));
         int zIndex = readIntStyle(styles.containsKey("z-index")
                 ? styles.get("z-index") : styles.get("zIndex"));
-        if (w <= 0) {
-            return new Frame(new Rect(), zIndex, child);
-        }
         int xPx = StyleHelper.standardUnitToPx(context, x);
         int yPx = StyleHelper.standardUnitToPx(context, y);
         int wPx = Math.max(0, StyleHelper.standardUnitToPx(context, w));

--- a/platforms/android/src/main/java/com/amap/agenui/render/component/impl/span/CustomStrikethroughSpan.java
+++ b/platforms/android/src/main/java/com/amap/agenui/render/component/impl/span/CustomStrikethroughSpan.java
@@ -1,5 +1,6 @@
 package com.amap.agenui.render.component.impl.span;
 
+import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.DashPathEffect;
 import android.graphics.Paint;
@@ -8,6 +9,8 @@ import android.text.style.LineBackgroundSpan;
 import android.view.Gravity;
 
 import androidx.annotation.NonNull;
+
+import com.amap.agenui.render.style.StyleHelper;
 
 /**
  * Custom strikethrough Span, supporting multiple line styles
@@ -37,6 +40,7 @@ public class CustomStrikethroughSpan implements LineBackgroundSpan {
     private final float thickness;     // decoration line thickness (pixels)
     private final Style style;         // decoration line style
     private final int gravity;         // text alignment
+    private final Context context;     // for standardUnitToPx conversion
 
     /**
      * Constructor
@@ -45,12 +49,14 @@ public class CustomStrikethroughSpan implements LineBackgroundSpan {
      * @param thickness decoration line thickness (pixels)
      * @param style     decoration line style
      * @param gravity   text alignment
+     * @param context   Android Context for unit conversion
      */
-    public CustomStrikethroughSpan(int color, float thickness, Style style, int gravity) {
+    public CustomStrikethroughSpan(int color, float thickness, Style style, int gravity, Context context) {
         this.color = color;
         this.thickness = thickness;
         this.style = style;
         this.gravity = gravity;
+        this.context = context;
     }
 
     @Override
@@ -127,8 +133,10 @@ public class CustomStrikethroughSpan implements LineBackgroundSpan {
      */
     private void drawDashedLine(Canvas canvas, Paint paint, float startX, float startY,
                                 float endX, float endY) {
-        // Dashed effect: segment length 10, gap 5
-        paint.setPathEffect(new DashPathEffect(new float[]{10, 5}, 0));
+        // Aligned with production config
+        float dashW = StyleHelper.standardUnitToPx(context, 4);
+        float dashG = StyleHelper.standardUnitToPx(context, 3);
+        paint.setPathEffect(new DashPathEffect(new float[]{dashW, dashG}, 0));
         canvas.drawLine(startX, startY, endX, endY, paint);
         paint.setPathEffect(null);
     }

--- a/platforms/android/src/main/java/com/amap/agenui/render/component/impl/span/CustomUnderlineSpan.java
+++ b/platforms/android/src/main/java/com/amap/agenui/render/component/impl/span/CustomUnderlineSpan.java
@@ -1,5 +1,6 @@
 package com.amap.agenui.render.component.impl.span;
 
+import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.DashPathEffect;
 import android.graphics.Paint;
@@ -8,6 +9,8 @@ import android.text.style.LineBackgroundSpan;
 import android.view.Gravity;
 
 import androidx.annotation.NonNull;
+
+import com.amap.agenui.render.style.StyleHelper;
 
 /**
  * Custom underline Span, supporting multiple line styles
@@ -37,6 +40,7 @@ public class CustomUnderlineSpan implements LineBackgroundSpan {
     private final float thickness;     // decoration line thickness (pixels)
     private final Style style;         // decoration line style
     private final int gravity;         // text alignment
+    private final Context context;     // for standardUnitToPx conversion
 
     /**
      * Constructor
@@ -45,12 +49,14 @@ public class CustomUnderlineSpan implements LineBackgroundSpan {
      * @param thickness decoration line thickness (pixels)
      * @param style     decoration line style
      * @param gravity   text alignment
+     * @param context   Android Context for unit conversion
      */
-    public CustomUnderlineSpan(int color, float thickness, Style style, int gravity) {
+    public CustomUnderlineSpan(int color, float thickness, Style style, int gravity, Context context) {
         this.color = color;
         this.thickness = thickness;
         this.style = style;
         this.gravity = gravity;
+        this.context = context;
     }
 
     @Override
@@ -91,8 +97,13 @@ public class CustomUnderlineSpan implements LineBackgroundSpan {
             textStart = left;
         }
 
-        // Calculate underline position (slightly below the text baseline)
-        float lineY = bottom - (bottom - baseline) * 0.2f;
+        // Calculate underline position just below glyph bottom,
+        // using font descent instead of line-box bottom to stay
+        // consistent across different line-height values.
+        // Clamp to [baseline + 1, bottom] so the line is always visible
+        // even when line-height is tight (small line-height).
+        float descent = paint.getFontMetrics().descent;
+        float lineY = Math.max(baseline + 1f, Math.min(baseline + descent + thickness, bottom));
 
         // Draw the decoration line starting from the actual text position
         switch (style) {
@@ -127,8 +138,10 @@ public class CustomUnderlineSpan implements LineBackgroundSpan {
      */
     private void drawDashedLine(Canvas canvas, Paint paint, float startX, float startY,
                                 float endX, float endY) {
-        // Dashed effect: segment length 10, gap 5
-        paint.setPathEffect(new DashPathEffect(new float[]{10, 5}, 0));
+        // Aligned with production config
+        float dashW = StyleHelper.standardUnitToPx(context, 4);
+        float dashG = StyleHelper.standardUnitToPx(context, 3);
+        paint.setPathEffect(new DashPathEffect(new float[]{dashW, dashG}, 0));
         canvas.drawLine(startX, startY, endX, endY, paint);
         paint.setPathEffect(null);
     }

--- a/platforms/android/src/main/java/com/amap/agenui/render/style/StyleHelper.java
+++ b/platforms/android/src/main/java/com/amap/agenui/render/style/StyleHelper.java
@@ -1036,7 +1036,7 @@ public class StyleHelper {
         int color = (decorationColor != null) ? parseColor(decorationColor) : textView.getCurrentTextColor();
         int thickness = parseDimension(decorationThickness, context);
         if (thickness <= 0) {
-            thickness = 1; // Default: 1px
+            thickness = StyleHelper.standardUnitToPx(context, 2); // Default: 2 a2ui unit
         }
 
         // 5. Get the TextView's gravity
@@ -1054,12 +1054,14 @@ public class StyleHelper {
         if (decorationLine.equals("underline")) {
             com.amap.agenui.render.component.impl.span.CustomUnderlineSpan.Style style = parseUnderlineStyle(decorationStyle);
             com.amap.agenui.render.component.impl.span.CustomUnderlineSpan span =
-                    new com.amap.agenui.render.component.impl.span.CustomUnderlineSpan(color, thickness, style, gravity);
+                    new com.amap.agenui.render.component.impl.span.CustomUnderlineSpan(
+                            color, thickness, style, gravity, context);
             spannableString.setSpan(span, 0, text.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         } else if (decorationLine.equals("line-through")) {
             com.amap.agenui.render.component.impl.span.CustomStrikethroughSpan.Style style = parseStrikethroughStyle(decorationStyle);
             com.amap.agenui.render.component.impl.span.CustomStrikethroughSpan span =
-                    new com.amap.agenui.render.component.impl.span.CustomStrikethroughSpan(color, thickness, style, gravity);
+                    new com.amap.agenui.render.component.impl.span.CustomStrikethroughSpan(
+                            color, thickness, style, gravity, context);
             spannableString.setSpan(span, 0, text.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
@@ -1202,6 +1204,9 @@ public class StyleHelper {
      * @return Converted pixel value
      */
     public static int standardUnitToPx(Context context, float value) {
+        if (context == null) {
+            return (int)value;
+        }
         // Standard unit must be divided by 2 before converting to dp
         float dipValue = value / 2;
         float density = context.getResources().getDisplayMetrics().density;
@@ -1320,5 +1325,74 @@ public class StyleHelper {
         }
 
         return null;
+    }
+
+    /**
+     * Resolve CSS margin from a styles map into pixel values.
+     * Handles both the shorthand "margin" (1~4 values) and individual
+     * "margin-top" / "margin-right" / "margin-bottom" / "margin-left"
+     * properties. Individual properties override the shorthand, matching
+     * CSS cascade / Yoga semantics (CSSStyleConverter::applyStyles).
+     *
+     * Mirrors {@link #resolveCSSPaddingPx} in naming convention and structure.
+     *
+     * @param styles CSS styles map
+     * @param context Android context for unit conversion
+     * @return Rect(left, top, right, bottom) in pixels, or null if no margin is present
+     */
+    @Nullable
+    public static Rect resolveCSSMarginPx(@Nullable Map<String, Object> styles,
+                                          @NonNull Context context) {
+        if (styles == null || styles.isEmpty()) {
+            return null;
+        }
+
+        int topPx = 0, rightPx = 0, bottomPx = 0, leftPx = 0;
+        boolean anyMarginPresent = false;
+
+        // 1. Parse shorthand "margin" via native edge-insets parser
+        if (styles.containsKey("margin")) {
+            String shorthand = String.valueOf(styles.get("margin")).trim();
+            if (!shorthand.isEmpty() && !shorthand.equalsIgnoreCase("null")) {
+                EdgeInsetsValue insets = AGenUI.nativeParseEdgeInsets(shorthand);
+                if (insets != null) {
+                    topPx    = resolveSidePx(insets.top,    context);
+                    rightPx  = resolveSidePx(insets.right,  context);
+                    bottomPx = resolveSidePx(insets.bottom, context);
+                    leftPx   = resolveSidePx(insets.left,   context);
+                    anyMarginPresent = true;
+                }
+            }
+        }
+
+        // 2. Individual properties override shorthand
+        if (styles.containsKey("margin-top")) {
+            topPx = parseDimension(styles.get("margin-top"), context);
+            anyMarginPresent = true;
+        }
+        if (styles.containsKey("margin-right")) {
+            rightPx = parseDimension(styles.get("margin-right"), context);
+            anyMarginPresent = true;
+        }
+        if (styles.containsKey("margin-bottom")) {
+            bottomPx = parseDimension(styles.get("margin-bottom"), context);
+            anyMarginPresent = true;
+        }
+        if (styles.containsKey("margin-left")) {
+            leftPx = parseDimension(styles.get("margin-left"), context);
+            anyMarginPresent = true;
+        }
+
+        if (!anyMarginPresent) {
+            return null;
+        }
+
+        if (topPx    < 0) topPx    = 0;
+        if (rightPx  < 0) rightPx  = 0;
+        if (bottomPx < 0) bottomPx = 0;
+        if (leftPx   < 0) leftPx   = 0;
+
+        Rect out = new Rect(leftPx, topPx, rightPx, bottomPx);
+        return out;
     }
 }

--- a/platforms/harmony/agenui/CHANGELOG.md
+++ b/platforms/harmony/agenui/CHANGELOG.md
@@ -85,6 +85,7 @@
 - **List Item 出现事件 & 首屏渲染埋点**：向集成层透出 list item appear 事件和 first-render trackInfo，用于数据分析和性能监控。
 - **Padding 解析接口开放**：开放 padding 解析接口，集成方可直接获取解析后的 padding 值。
 - **linear-gradient 渐变背景支持**：Text、Button、List、Checkbox、Divider、TextField 组件的 background-color 统一使用基类方法处理，支持 `linear-gradient` 渐变色。
+- **虚线下划线支持**：在 iOS、Android 和鸿蒙端新增自定义虚线下划线样式，通过 `text-decoration` 属性控制。
 
 ### Bug 修复
 
@@ -92,11 +93,16 @@
 - (iOS) 修复阴影偏淡问题——设定 `shadowOpacity` 为 `1.0`，防止 alpha 被乘两次。
 - (iOS) 修复 `Surface.updateSize()` 递归布局通知导致栈溢出崩溃。
 - (iOS) 修复 `TabsComponent.addChild` 闭包强引用子组件导致永久内存泄漏。
-- (iOS) 修复并发 `ImageLoader` 注册导致 ARC 引用计数竞争崩溃。
-- (iOS) 修复并发 Function 注册/注销导致 Swift `Dictionary` 竞争崩溃。
+- (iOS) 修复并发 `ImageLoader` 注册导致 ARC 引用计数竞争崩溃 (#83354930)。
+- (iOS) 修复并发 Function 注册/注销导致 Swift `Dictionary` 竞争崩溃 (#83354917)。
 - (Android) 修复 Image 显式 `0px` 被图片固有尺寸覆盖导致的布局抖动。
-- (Android) 修复删除线位置错误问题，改进行高处理逻辑。
-- (鸿蒙) 修复 Row 子元素重叠、垂直居中对齐异常。
+- (Android) 修复删除线位置错误问题，改进行高处理逻辑 (#83884229)。
+- (鸿蒙) 修复 Row 子元素重叠、垂直居中对齐异常 (#83823723)。
 - (鸿蒙) 修复 API 17 崩溃——使用 `dlsym` wrapper 替换 `OH_ArkUI_PostFrameCallback`。
+- (全平台) 优化大图加载卡顿问题。
+- (全平台) 修复下划线多行计算问题和 `thickness` 单位转换。
+- (iOS) 修复删除线简写写法不生效。
+- (全平台) 修复图片裁剪尺寸未乘以屏幕密度。
+- (全平台) 修复横滑 List 无法动态追加 child 的问题。
 
 ---

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/bridge/image_loader_bridge.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/bridge/image_loader_bridge.cpp
@@ -393,6 +393,60 @@ void ImageLoaderBridge::setImagePixelMapFromBytes(const PixelMapData& pixelMap) 
     if (cb) cb(pixelMap.requestId, true, false);
 }
 
+void ImageLoaderBridge::setImagePixelMapFromNative(const std::string& requestId, OH_PixelmapNative* nativePixelMap) {
+    ImageLoadCallback cb;
+    ArkUI_NodeHandle handle = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = pending_callbacks_.find(requestId);
+        if (it == pending_callbacks_.end()) {
+            HM_LOGW("ImageLoaderBridge::setImagePixelMapFromNative - unknown requestId=%s (cancelled or not found)",
+                requestId.c_str());
+            if (nativePixelMap != nullptr) {
+                OH_PixelmapNative_Release(nativePixelMap);
+            }
+            return;
+        }
+        cb = std::move(it->second);
+        pending_callbacks_.erase(it);
+
+        auto hit = pending_handles_.find(requestId);
+        if (hit != pending_handles_.end()) {
+            handle = hit->second;
+            pending_handles_.erase(hit);
+        }
+    }
+
+    HM_LOGI("ImageLoaderBridge::setImagePixelMapFromNative - requestId=%s handle=%p pixelMap=%p",
+        requestId.c_str(), handle, nativePixelMap);
+
+    if (handle == nullptr || nativePixelMap == nullptr) {
+        HM_LOGE("ImageLoaderBridge::setImagePixelMapFromNative - invalid params, requestId=%s", requestId.c_str());
+        if (nativePixelMap != nullptr) {
+            OH_PixelmapNative_Release(nativePixelMap);
+        }
+        if (cb) cb(requestId, false, false);
+        return;
+    }
+
+    ArkUI_DrawableDescriptor* descriptor = OH_ArkUI_DrawableDescriptor_CreateFromPixelMap(nativePixelMap);
+    if (descriptor == nullptr) {
+        HM_LOGE("ImageLoaderBridge::setImagePixelMapFromNative - OH_ArkUI_DrawableDescriptor_CreateFromPixelMap failed, requestId=%s",
+            requestId.c_str());
+        OH_PixelmapNative_Release(nativePixelMap);
+        if (cb) cb(requestId, false, false);
+        return;
+    }
+
+    ArkUI_AttributeItem item = { .object = descriptor };
+    g_nodeAPI->setAttribute(handle, NODE_IMAGE_SRC, &item);
+    OH_ArkUI_DrawableDescriptor_Dispose(descriptor);
+    OH_PixelmapNative_Release(nativePixelMap);
+    HM_LOGI("ImageLoaderBridge::setImagePixelMapFromNative - PixelMap set to node OK, requestId=%s",
+        requestId.c_str());
+    if (cb) cb(requestId, true, false);
+}
+
 // ---- Failure / Cancel Callback ----
 
 void ImageLoaderBridge::onFailed(const std::string& requestId, bool isCancelled) {

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/bridge/image_loader_bridge.h
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/bridge/image_loader_bridge.h
@@ -95,6 +95,7 @@ public:
     // PixelMap delivery, called by NAPI setImagePixelMap on the JS main thread
 
     void setImagePixelMapFromBytes(const PixelMapData& pixelMap);
+    void setImagePixelMapFromNative(const std::string& requestId, OH_PixelmapNative* nativePixelMap);
 
     // Failure and cancellation callback, called by NAPI onImageLoadFailed on the JS main thread
 

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/measure/text_component_measurement.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/measure/text_component_measurement.cpp
@@ -81,13 +81,8 @@ bool TextComponentMeasurement::buildParam(const nlohmann::json& j,
 
     // ---- Extract text content (attributes flattened at root level: text / label) ----
     // stringify() flattens attributes to root level without "attrs" wrapper
-    if (j.contains("text")) {
-        const auto& textVal = j["text"];
-        if (textVal.is_string()) {
-            outText = textVal.get<std::string>();
-        } else if (textVal.is_number()) {
-            outText = textVal.dump();
-        }
+    if (j.contains("text") && j["text"].is_string()) {
+        outText = j["text"].get<std::string>();
     } else if (j.contains("label") && j["label"].is_string()) {
         outText = j["label"].get<std::string>();
     }

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_component.cpp
@@ -8,9 +8,11 @@
 #include <vector>
 
 #include "a2ui_component.h"
+#include "utils/a2ui_parse_utils.h"
 #include "a2ui/measure/a2ui_platform_layout_bridge.h"
 #include "a2ui/utils/a2ui_unit_utils.h"
 #include "a2ui/utils/a2ui_color_palette.h"
+#include "a2ui/utils/a2ui_shadow_utils.h"
 #include "a2ui/utils/a2ui_animate_utils.h"
 #include "a2ui_component_state.h"
 #include "agenui_engine_entry.h"
@@ -169,6 +171,17 @@ void A2UIComponent::updateLayoutProperties(const nlohmann::json& newProps) {
             if (!m_parent || m_parent->shouldApplyChildLayoutSize(this)) {
                 getNode().setWidth(m_width);
                 getNode().setHeight(m_height);
+            }
+            // Root node has no Yoga parent to consume its margin.
+            // Yoga's getLayoutLeft/Top already include margin-left/top in the
+            // position, but margin-bottom/right are lost. Apply them to the
+            // ArkUI node so the parent Stack can allocate the correct space.
+            if (m_id == "root") {
+                float mt = 0, mr = 0, mb = 0, ml = 0;
+                resolveUserMargin(stylesJson, mt, mr, mb, ml);
+                if (mb > 0 || mr > 0) {
+                    getNode().setMargin(0, mr, mb, 0);
+                }
             }
             if (m_parent) {
                 m_parent->onChildLayoutSizeChanged(this);
@@ -579,63 +592,7 @@ uint32_t A2UIComponent::parseColorWithToken(const nlohmann::json& colorValue, ui
     return fallbackValue;
 }
 
-/**
- * Extract the raw URL from a CSS url(...) value.
- * Supported formats:
- *   url(https://example.com/image.png)
- *   url('https://example.com/image.png')
- *   url("https://example.com/image.png")
- * Returns the original string when the value is not a url(...) expression.
- */
-static std::string extractUrlFromCssUrl(const std::string& value) {
-    if (value.empty()) {
-        return "";
-    }
-    
-    size_t start = 0;
-    while (start < value.size() && (value[start] == ' ' || value[start] == '\t')) {
-        start++;
-    }
-    
-    if (value.compare(start, 4, "url(") != 0) {
-        return value;
-    }
-    
-    size_t parenStart = start + 3;
-    while (parenStart < value.size() && value[parenStart] != '(') {
-        parenStart++;
-    }
-    if (parenStart >= value.size()) {
-        return value;
-    }
-    parenStart++;
-    
-    while (parenStart < value.size() && (value[parenStart] == ' ' || value[parenStart] == '\t')) {
-        parenStart++;
-    }
-    
-    size_t parenEnd = value.rfind(')');
-    if (parenEnd == std::string::npos || parenEnd <= parenStart) {
-        return value;
-    }
-    
-    std::string inner = value.substr(parenStart, parenEnd - parenStart);
-    
-    size_t innerEnd = inner.size();
-    while (innerEnd > 0 && (inner[innerEnd - 1] == ' ' || inner[innerEnd - 1] == '\t')) {
-        innerEnd--;
-    }
-    inner = inner.substr(0, innerEnd);
-    
-    if (inner.size() >= 2) {
-        if ((inner[0] == '"' && inner[inner.size() - 1] == '"') ||
-            (inner[0] == '\'' && inner[inner.size() - 1] == '\'')) {
-            inner = inner.substr(1, inner.size() - 2);
-        }
-    }
-    
-    return inner;
-}
+// extractUrlFromCssUrl is provided by utils/a2ui_parse_utils.h (inline).
 
 void A2UIComponent::applyBackgroundImage(const nlohmann::json& styles) {
     if (!m_nodeHandle) {
@@ -889,6 +846,33 @@ void A2UIComponent::applyBorderStyles(const nlohmann::json& properties) {
             node.setBorderColor(color);
         }
     }
+}
+
+void A2UIComponent::applyFilter(const nlohmann::json& properties) {
+    if (!m_nodeHandle) {
+        return;
+    }
+
+    if (!properties.contains("styles") || !properties["styles"].is_object()) {
+        return;
+    }
+
+    const auto& styles = properties["styles"];
+    if (!styles.contains("filter") || !styles["filter"].is_string()) {
+        return;
+    }
+
+    DropShadowParams params = parseDropShadow(styles["filter"].get<std::string>());
+    if (!params.valid) {
+        return;
+    }
+
+    uint32_t color = parseColor(params.colorStr);
+    if (color == kColorTransparent && params.colorStr != "#00000000" && params.colorStr != "rgba(0, 0, 0, 0)" &&
+        params.colorStr != "rgba(0,0,0,0)" && params.colorStr != "rgb(0, 0, 0)") {
+        return;
+    }
+    A2UINode(m_nodeHandle).setCustomShadow(params.blurRadius, params.offsetX, params.offsetY, color);
 }
 
 void A2UIComponent::applyAccessibility(const nlohmann::json& properties) {

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_component.h
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_component.h
@@ -344,6 +344,14 @@ protected:
     void applyBorderStyles(const nlohmann::json& properties);
 
     /**
+     * Apply the CSS filter: drop-shadow(...) style to the native node.
+     * Shared by container components (Column, Row, ...) that otherwise have no
+     * shadow handling. Card/RichText keep their own local implementations.
+     * @param properties Properties JSON object (contains "styles" field)
+     */
+    void applyFilter(const nlohmann::json& properties);
+
+    /**
      * Apply accessibility properties from DSL to the native ArkUI node.
      * Maps "accessibility.label" to NODE_ACCESSIBILITY_TEXT and
      * "accessibility.description" to NODE_ACCESSIBILITY_DESCRIPTION.

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_node.h
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_node.h
@@ -88,20 +88,29 @@ public:
 
     /**
      * Set a custom shadow, matching CSS drop-shadow / box-shadow semantics.
-     * NODE_CUSTOM_SHADOW parameters:
-     *   [0] blur   - blur radius in px
-     *   [1] spread - spread radius, always 0 here
-     *   [2] offsetX - x offset in physical px
-     *   [3] offsetY - y offset in physical px
-     *   [4] type   - shadow type, ARKUI_SHADOW_TYPE_COLOR = 0
-     *   [5] color  - color in 0xAARRGGBB
-     *   [6] fill   - fill flag, 0 means no fill
-     * All inputs use a2ui units and are converted internally.
+     * NODE_CUSTOM_SHADOW parameters. Harmony's public docs define blur and
+     * offsets in px.
+     *   [0] blur    - blur radius (documented as px)
+     *   [1] coloring - coloring strategy flag (0 = disabled, default)
+     *   [2] offsetX - x offset (documented as px)
+     *   [3] offsetY - y offset (documented as px)
+     *   [4] type    - shadow type, ARKUI_SHADOW_TYPE_COLOR = 0
+     *   [5] color   - color in 0xAARRGGBB
+     *   [6] fill    - fill flag. Keep this disabled so CSS drop-shadow only
+     *                 draws the outer shadow instead of filling the source shape.
      */
     void setCustomShadow(float blurA2ui, float offsetXA2ui, float offsetYA2ui, uint32_t color) {
+        float blurPx = UnitConverter::a2uiToPx(blurA2ui);
+        // Harmony's NODE_CUSTOM_SHADOW behaves inconsistently at exactly 0 blur
+        // for CSS drop-shadow edge cases. Clamp to the smallest practical
+        // positive px value so 0px shadows remain visually aligned with the
+        // other platforms instead of disappearing or degrading.
+        if (blurPx <= 0.0f) {
+            blurPx = 1.0f;
+        }
         ArkUI_NumberValue value[] = {
-            {.f32 = UnitConverter::a2uiToVp(blurA2ui)},
-            {.f32 = 0.0f},
+            {.f32 = blurPx},
+            {.i32 = 0},
             {.f32 = UnitConverter::a2uiToPx(offsetXA2ui)},
             {.f32 = UnitConverter::a2uiToPx(offsetYA2ui)},
             {.i32 = 0},
@@ -638,9 +647,10 @@ public:
         g_nodeAPI->setAttribute(m_nodeHandle, NODE_TEXT_ELLIPSIS_MODE, &item);
     }
 
-    void setTextDecoration(ArkUI_TextDecorationType type, uint32_t color) {
-        ArkUI_NumberValue value[] = {{.i32 = type}, {.u32 = color}};
-        ArkUI_AttributeItem item = {value, 2};
+    void setTextDecoration(ArkUI_TextDecorationType type, uint32_t color,
+                           ArkUI_TextDecorationStyle style = ARKUI_TEXT_DECORATION_STYLE_SOLID) {
+        ArkUI_NumberValue value[] = {{.i32 = type}, {.u32 = color}, {.i32 = style}};
+        ArkUI_AttributeItem item = {value, 3};
         g_nodeAPI->setAttribute(m_nodeHandle, NODE_TEXT_DECORATION, &item);
     }
 

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_surface.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/a2ui_surface.cpp
@@ -6,6 +6,7 @@
 
 #include "a2ui_component.h"
 #include "log/a2ui_capi_log.h"
+#include "utils/a2ui_parse_utils.h"
 
 namespace a2ui {
 
@@ -380,12 +381,28 @@ void A2UISurface::notifyRootContentSizeIfChanged() {
     if (currentHeight <= 0.0f) {
         return;
     }
+    float currentWidth = rootComponent_->getWidth();
+
+    // Root node has no Yoga parent to consume its margin.
+    // Yoga's getLayoutLeft/Top already include margin-left/top in the
+    // position (see YGNode::setPosition), so those are handled via
+    // setPosition(m_x, m_y). Only margin-bottom/right are lost — add
+    // them to the reported content size so the host container can
+    // allocate the correct total space.
+    const auto& props = rootComponent_->getProperties();
+    if (props.contains("styles") && props["styles"].is_object()) {
+        float mt = 0, mr = 0, mb = 0, ml = 0;
+        resolveUserMargin(props["styles"], mt, mr, mb, ml);
+        // top/left already in Yoga position (m_x/m_y), only add bottom/right
+        currentWidth  += mr;
+        currentHeight += mb;
+    }
+
     // Only notify when height actually changes (avoid redundant callbacks during streaming).
     if (std::abs(currentHeight - lastNotifiedRootHeight_) < 0.5f) {
         return;
     }
     lastNotifiedRootHeight_ = currentHeight;
-    float currentWidth = rootComponent_->getWidth();
     HM_LOGI("notifyRootContentSizeIfChanged: surfaceId=%s w=%.1f h=%.1f",
             surfaceId_.c_str(), currentWidth, currentHeight);
     contentSizeChangedCallback_(surfaceId_, currentWidth, currentHeight);

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/column_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/column_component.cpp
@@ -73,6 +73,7 @@ void ColumnComponent::applyStyles(const nlohmann::json& properties) {
     // Delegate background and border handling to the base class
     applyBackgroundColor(properties);
     applyBorderStyles(properties);
+    applyFilter(properties);
 }
 
 } // namespace a2ui

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/row_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/row_component.cpp
@@ -50,6 +50,7 @@ void RowComponent::applyStyles(const nlohmann::json& properties) {
     // Delegate background and border handling to the base class
     applyBackgroundColor(properties);
     applyBorderStyles(properties);
+    applyFilter(properties);
 }
 
 // ---- Justify ----

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/text_component.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/render/components/text_component.cpp
@@ -119,8 +119,6 @@ void TextComponent::applyTextContent(const nlohmann::json& properties) {
 
         if (chunkValue.is_string()) {
             chunkContent = chunkValue.get<std::string>();
-        } else if (chunkValue.is_number()) {
-            chunkContent = chunkValue.dump();
         } else if (chunkValue.is_object()) {
             auto litIt = chunkValue.find("literalString");
             if (litIt != chunkValue.end() && litIt->is_string()) {
@@ -150,10 +148,6 @@ void TextComponent::applyTextContent(const nlohmann::json& properties) {
         // Format 2: {"text": "Hello"}
         else if (textValue.is_string()) {
             textContent = textValue.get<std::string>();
-        }
-        // Format 3: {"text": 1} — number type, convert to string
-        else if (textValue.is_number()) {
-            textContent = textValue.dump();
         }
 
         if (!textContent.empty()) {
@@ -492,7 +486,24 @@ void TextComponent::applyBorderDecorationStyles(const nlohmann::json& styles, fl
         }
 
         if (decorationType != ARKUI_TEXT_DECORATION_TYPE_NONE) {
-            node.setTextDecoration(decorationType, decorationColor);
+            // Parse text-decoration-style
+            std::string styleStr = "solid";
+            if (styles.find("text-decoration-style") != styles.end() && styles["text-decoration-style"].is_string()) {
+                styleStr = styles["text-decoration-style"].get<std::string>();
+            }
+
+            ArkUI_TextDecorationStyle decorationStyle = ARKUI_TEXT_DECORATION_STYLE_SOLID;
+            if (styleStr == "dashed") {
+                decorationStyle = ARKUI_TEXT_DECORATION_STYLE_DASHED;
+            } else if (styleStr == "dotted") {
+                decorationStyle = ARKUI_TEXT_DECORATION_STYLE_DOTTED;
+            } else if (styleStr == "double") {
+                decorationStyle = ARKUI_TEXT_DECORATION_STYLE_DOUBLE;
+            } else if (styleStr == "wavy") {
+                decorationStyle = ARKUI_TEXT_DECORATION_STYLE_WAVY;
+            }
+
+            node.setTextDecoration(decorationType, decorationColor, decorationStyle);
         }
     }
 

--- a/platforms/harmony/agenui/src/main/cpp/a2ui/utils/a2ui_parse_utils.h
+++ b/platforms/harmony/agenui/src/main/cpp/a2ui/utils/a2ui_parse_utils.h
@@ -6,6 +6,7 @@
 #include <nlohmann/json.hpp>
 
 #include "log/a2ui_capi_log.h"
+#include "style_parser/agenui_edge_insets_parser.h"
 
 namespace a2ui {
 
@@ -117,6 +118,62 @@ inline std::string extractUrlFromCssUrl(const std::string& value) {
     }
 
     return inner;
+}
+
+/**
+ * Resolve CSS `margin` shorthand + `margin-*` overrides into four a2ui-px
+ * edge values. Negative results are clamped to 0. When the styles object has
+ * no `margin*` keys, all four outputs are 0.
+ *
+ * Mirrors padding_utils::resolveUserPadding in structure and parser usage.
+ */
+inline void resolveUserMargin(const nlohmann::json& styles,
+                           float& top, float& right, float& bottom, float& left) {
+    top = right = bottom = left = 0.0f;
+    if (styles.is_null() || !styles.is_object()) return;
+
+    // Shorthand: `margin`
+    auto it = styles.find("margin");
+    if (it != styles.end()) {
+        if (it->is_number()) {
+            const float v = it->get<float>();
+            const float clamped = v > 0.0f ? v : 0.0f;
+            top = right = bottom = left = clamped;
+        } else if (it->is_string()) {
+            const std::string& raw = it->get_ref<const std::string&>();
+            ::agenui::EdgeInsets parsed;
+            if (::agenui::EdgeInsetsParser::parse(raw, parsed)) {
+                auto sidePx = [](const ::agenui::EdgeInsetValue& s) -> float {
+                    if (s.isCalc) return 0.0f;
+                    return (s.unit == ::agenui::EdgeInsetUnit::Px) ? s.value : 0.0f;
+                };
+                top    = sidePx(parsed.top);
+                right  = sidePx(parsed.right);
+                bottom = sidePx(parsed.bottom);
+                left   = sidePx(parsed.left);
+            }
+        }
+    }
+
+    // Per-edge overrides take precedence over the shorthand.
+    float v = 0.0f;
+    if ((it = styles.find("margin-top")) != styles.end() && parseCssLength(*it, 0.0f) >= 0.0f) {
+        v = parseCssLength(*it, 0.0f); top = v;
+    }
+    if ((it = styles.find("margin-right")) != styles.end()) {
+        v = parseCssLength(*it, 0.0f); right = v;
+    }
+    if ((it = styles.find("margin-bottom")) != styles.end()) {
+        v = parseCssLength(*it, 0.0f); bottom = v;
+    }
+    if ((it = styles.find("margin-left")) != styles.end()) {
+        v = parseCssLength(*it, 0.0f); left = v;
+    }
+
+    if (top < 0.0f) top = 0.0f;
+    if (right < 0.0f) right = 0.0f;
+    if (bottom < 0.0f) bottom = 0.0f;
+    if (left < 0.0f) left = 0.0f;
 }
 
 } // namespace a2ui

--- a/platforms/harmony/agenui/src/main/cpp/napi_image.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/napi_image.cpp
@@ -79,6 +79,38 @@ napi_value SetImagePixelMap(napi_env env, napi_callback_info info) {
     return ret;
 }
 
+napi_value SetImagePixelMapNative(napi_env env, napi_callback_info info) {
+    size_t argc = 2;
+    napi_value args[2];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    if (argc < 2) {
+      HM_LOGE("SetImagePixelMapNative: Expected 2 arguments, got %zu", argc);
+      napi_value result;
+      napi_get_undefined(env, &result);
+      return result;
+    }
+
+    std::string requestId = napiGetString(env, args[0]);
+
+    OH_PixelmapNative* nativePixelMap = nullptr;
+    Image_ErrorCode err = OH_PixelmapNative_ConvertPixelmapNativeFromNapi(env, args[1], &nativePixelMap);
+    if (err != IMAGE_SUCCESS || nativePixelMap == nullptr) {
+        HM_LOGE("SetImagePixelMapNative: convert pixelMap failed, requestId=%s err=%d",
+            requestId.c_str(), err);
+        a2ui::ImageLoaderBridge::getInstance().onFailed(requestId, false);
+        napi_value ret;
+        napi_get_undefined(env, &ret);
+        return ret;
+    }
+
+    a2ui::ImageLoaderBridge::getInstance().setImagePixelMapFromNative(requestId, nativePixelMap);
+
+    napi_value ret;
+    napi_get_undefined(env, &ret);
+    return ret;
+}
+
 napi_value OnImageLoadFailed(napi_env env, napi_callback_info info) {
     size_t argc = 2;
     napi_value args[2];

--- a/platforms/harmony/agenui/src/main/cpp/napi_init.cpp
+++ b/platforms/harmony/agenui/src/main/cpp/napi_init.cpp
@@ -477,6 +477,7 @@ static napi_value Init(napi_env env, napi_value exports)
         { "registerComponent", nullptr, RegisterComponent, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "registerImageLoader", nullptr, RegisterImageLoader, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setImagePixelMap", nullptr, SetImagePixelMap, nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "setImagePixelMapNative", nullptr, SetImagePixelMapNative, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "onImageLoadFailed", nullptr, OnImageLoadFailed, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "surfaceStartBlankCheck", nullptr, Surface_startBlankCheck, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "surfaceCancelBlankCheck", nullptr, Surface_cancelBlankCheck, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/platforms/harmony/agenui/src/main/cpp/napi_internal.h
+++ b/platforms/harmony/agenui/src/main/cpp/napi_internal.h
@@ -76,6 +76,7 @@ napi_value UnregisterMeasurement(napi_env env, napi_callback_info info);
 // napi_image.cpp
 napi_value RegisterImageLoader(napi_env env, napi_callback_info info);
 napi_value SetImagePixelMap(napi_env env, napi_callback_info info);
+napi_value SetImagePixelMapNative(napi_env env, napi_callback_info info);
 napi_value OnImageLoadFailed(napi_env env, napi_callback_info info);
 
 // napi_theme.cpp

--- a/platforms/harmony/agenui/src/main/cpp/types/liba2ui-capi/Index.d.ts
+++ b/platforms/harmony/agenui/src/main/cpp/types/liba2ui-capi/Index.d.ts
@@ -200,6 +200,9 @@ export const registerImageLoader: (loader: object) => void;
 /** Applies raw image pixel data to the matching ArkUI image node. */
 export const setImagePixelMap: (requestId: string, buffer: ArrayBuffer, width: number, height: number, pixelFormat: number, alphaType: number) => void;
 
+/** Applies a native PixelMap object to the matching ArkUI image node. */
+export const setImagePixelMapNative: (requestId: string, pixelMap: object) => void;
+
 /** Reports image load failure or cancellation from ETS. */
 export const onImageLoadFailed: (requestId: string, isCancelled: boolean) => void;
 

--- a/platforms/harmony/agenui/src/main/ets/agenui/ImageLoader.ets
+++ b/platforms/harmony/agenui/src/main/ets/agenui/ImageLoader.ets
@@ -18,8 +18,17 @@ import image from '@ohos.multimedia.image';
  * Uses a Uint8Array snapshot to move pixel data across layers and avoid native buffer lifetime issues.
  */
 export interface PixelData {
-  /** Raw pixel bytes; actual format is indicated by the pixelFormat field (e.g. BGRA_8888 = 4) */
+  /**
+   * Raw pixel bytes; actual format is indicated by the pixelFormat field (e.g. BGRA_8888 = 4).
+   * When pixelMap is provided directly, the loader may leave this buffer empty.
+   */
   bytes: Uint8Array;
+  /**
+   * Optional native PixelMap object.
+   * Preferred on Harmony when the loader can return a PixelMap directly, because it avoids
+   * JS raw-buffer reconstruction and preserves the original alpha semantics.
+   */
+  pixelMap?: image.PixelMap | null;
   /** Image width in px */
   width: number;
   /** Image height in px */

--- a/platforms/harmony/agenui/src/main/ets/agenui/bridge/AGenUIEngineBridge.ets
+++ b/platforms/harmony/agenui/src/main/ets/agenui/bridge/AGenUIEngineBridge.ets
@@ -18,6 +18,7 @@ import {
   setDayNightMode,
   registerImageLoader as nativeRegisterImageLoader,
   setImagePixelMap,
+  setImagePixelMapNative,
   onImageLoadFailed,
   createSurfaceManager as nativeCreateSurfaceManager,
   destroySurfaceManager as nativeDestroySurfaceManager,
@@ -203,6 +204,11 @@ export class AGenUIEngineBridge {
             if (result !== null && result.image != null) {
               const pd = result.image;
               try {
+                const nativePixelMap = pd.pixelMap;
+                if (nativePixelMap != null) {
+                  setImagePixelMapNative(requestId, nativePixelMap as object);
+                  return;
+                }
                 if (!pd.bytes || pd.bytes.byteLength === 0 || pd.width <= 0 || pd.height <= 0) {
                   hilog.error(0x0000, 'AGenUIBridge', `invalid PixelData: bytes=%{public}s %{public}d x %{public}d`, `${pd.bytes?.byteLength}`, pd.width, pd.height);
                   onImageLoadFailed(requestId, false);

--- a/platforms/ios/AGenUI/Classes/Render/Component/CSS/CSSMarginResolver.swift
+++ b/platforms/ios/AGenUI/Classes/Render/Component/CSS/CSSMarginResolver.swift
@@ -1,0 +1,147 @@
+//
+//  CSSMarginResolver.swift
+//  AGenUI
+//
+//  Shared CSS `margin` resolver used by Surface to compute root content size.
+//
+//  Parsing rules (kept in lockstep with Android / Harmony):
+//    All shorthand and per-edge string parsing is delegated to the canonical
+//    C++ `EdgeInsetsParser` via `AGenUIEdgeInsetsBridge`. Only `px` (and
+//    unitless, which the parser normalizes to px) is honored on the platform
+//    layer; every other CSS unit collapses to 0. The render layer
+//    intentionally stays px-only so the three platforms render identically
+//    without dragging viewport / font-baseline / physical-unit math into
+//    platform code.
+//    `margin-top/right/bottom/left` always override the shorthand.
+//    Negative values are clamped to 0.
+//    Numeric tokens (NSNumber / Int / Double / CGFloat) are accepted and
+//    treated as raw px (legacy contract used by some style sources).
+//
+//  Output: four iOS points, scaled by `pointScale = 0.5` to match the same
+//  px -> pt scaling used by font-size and line-height across the codebase.
+
+import UIKit
+
+/// Resolved CSS margin in iOS points. Edges are clamped to >= 0.
+public struct CSSMargin {
+    public let top: CGFloat
+    public let right: CGFloat
+    public let bottom: CGFloat
+    public let left: CGFloat
+
+    public static let zero = CSSMargin(top: 0, right: 0, bottom: 0, left: 0)
+
+    public var hasAny: Bool {
+        return top > 0 || right > 0 || bottom > 0 || left > 0
+    }
+}
+
+public enum CSSMarginResolver {
+
+    /// Same px -> pt scaling factor used by font-size and line-height
+    /// elsewhere in the iOS render layer (see `TextComponent.BS_POINT_SCALE`).
+    public static let pointScale: CGFloat = 0.5
+
+    /// Resolve a CSS `styles` dictionary into a 4-edge margin tuple.
+    /// Returns `CSSMargin.zero` when no margin-* key is present so callers
+    /// can rely on a non-nil result and decide whether to apply or skip.
+    public static func resolve(_ styles: [String: Any]) -> CSSMargin {
+        var top: CGFloat = 0
+        var right: CGFloat = 0
+        var bottom: CGFloat = 0
+        var left: CGFloat = 0
+
+        // Shorthand: `margin`
+        if let raw = styles["margin"], let shorthand = resolveShorthand(raw) {
+            top = shorthand.top
+            right = shorthand.right
+            bottom = shorthand.bottom
+            left = shorthand.left
+        }
+
+        // Per-edge overrides
+        if let v = parseLengthPt(styles["margin-top"]) { top = v }
+        if let v = parseLengthPt(styles["margin-right"]) { right = v }
+        if let v = parseLengthPt(styles["margin-bottom"]) { bottom = v }
+        if let v = parseLengthPt(styles["margin-left"]) { left = v }
+
+        return CSSMargin(
+            top: max(0, top),
+            right: max(0, right),
+            bottom: max(0, bottom),
+            left: max(0, left)
+        )
+    }
+
+    /// Returns true when the styles object carries any `margin*` key.
+    public static func hasAnyMarginKey(_ styles: [String: Any]) -> Bool {
+        return styles["margin"] != nil
+            || styles["margin-top"] != nil
+            || styles["margin-right"] != nil
+            || styles["margin-bottom"] != nil
+            || styles["margin-left"] != nil
+    }
+
+    /// Parse a single CSS length token into iOS points. Accepts String (any
+    /// CSS length unit, parsed via the canonical C++ parser), NSNumber, Int,
+    /// Double, CGFloat. Numeric tokens are treated as raw px and scaled by
+    /// `pointScale`. Returns nil for unparseable input.
+    static func parseLengthPt(_ value: Any?) -> CGFloat? {
+        guard let value = value else { return nil }
+        if let s = value as? String {
+            let trimmed = s.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { return nil }
+            // Reuse the shorthand parser by treating a single token as a
+            // 1-value shorthand, then take any side (all four are equal).
+            guard let insets = AGenUIEdgeInsetsBridge.parse(trimmed) else { return nil }
+            return resolveSidePt(insets.top)
+        }
+        if let n = value as? NSNumber {
+            return CGFloat(n.doubleValue) * pointScale
+        }
+        if let d = value as? Double {
+            return CGFloat(d) * pointScale
+        }
+        if let i = value as? Int {
+            return CGFloat(i) * pointScale
+        }
+        if let f = value as? CGFloat {
+            return f * pointScale
+        }
+        return nil
+    }
+
+    // MARK: - Private
+
+    /// Parse `margin` shorthand value into a 4-edge tuple. Strings are
+    /// routed through the canonical C++ parser; bare numbers are treated as
+    /// uniform px on all four edges.
+    private static func resolveShorthand(_ raw: Any) -> CSSMargin? {
+        if let str = raw as? String {
+            let trimmed = str.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { return nil }
+            guard let insets = AGenUIEdgeInsetsBridge.parse(trimmed) else { return nil }
+            return CSSMargin(
+                top:    resolveSidePt(insets.top),
+                right:  resolveSidePt(insets.right),
+                bottom: resolveSidePt(insets.bottom),
+                left:   resolveSidePt(insets.left)
+            )
+        }
+        if let n = parseLengthPt(raw) {
+            return CSSMargin(top: n, right: n, bottom: n, left: n)
+        }
+        return nil
+    }
+
+    /// Convert a single parsed edge value into iOS points. Only `px` (and
+    /// unitless, which the C++ parser normalizes to px) is honored; every
+    /// other CSS unit collapses to 0 so the three platforms stay aligned.
+    private static func resolveSidePt(_ side: AGUIEdgeInsetSide) -> CGFloat {
+        if side.isCalc { return 0 }
+        if side.unit == .px {
+            return CGFloat(side.value) * pointScale
+        }
+        return 0
+    }
+}

--- a/platforms/ios/AGenUI/Classes/Render/Component/Component.swift
+++ b/platforms/ios/AGenUI/Classes/Render/Component/Component.swift
@@ -370,7 +370,7 @@ public enum MeasureMode: Int {
         let y = cgFloatValue(styles["y"]) * Component.BS_POINT_SCALE
         let width = max(0, cgFloatValue(styles["width"]) * Component.BS_POINT_SCALE)
         let height = max(0, cgFloatValue(styles["height"]) * Component.BS_POINT_SCALE)
-        
+
         var newFrame = self.frame
         newFrame.origin.x = x
         newFrame.origin.y = y

--- a/platforms/ios/AGenUI/Classes/Render/Component/Impl/ImageComponent.swift
+++ b/platforms/ios/AGenUI/Classes/Render/Component/Impl/ImageComponent.swift
@@ -261,8 +261,8 @@ class ImageComponent: Component {
             ImageLoadOptionsKey.surfaceId: surface?.surfaceId ?? "",
             ImageLoadOptionsKey.componentId: componentId
         ]
-        let w = CGFloat(yogaWidth) * 0.5
-        let h = CGFloat(yogaHeight) * 0.5
+        let w = CGFloat(yogaWidth) * Component.BS_POINT_SCALE * UIScreen.main.scale
+        let h = CGFloat(yogaHeight) * Component.BS_POINT_SCALE * UIScreen.main.scale
         if w > 0 {
             options[ImageLoadOptionsKey.width] = w
         }

--- a/platforms/ios/AGenUI/Classes/Render/Component/Impl/ListComponent.swift
+++ b/platforms/ios/AGenUI/Classes/Render/Component/Impl/ListComponent.swift
@@ -179,9 +179,14 @@ private class YogaCollectionViewLayout: UICollectionViewLayout {
         }
     }
 
-    /// Total scrollable content size — union of all child Yoga frames
+
+    /// Clamp content height to no more than the viewport height, to prevent vertical scrolling.
     override var collectionViewContentSize: CGSize {
-        return contentBounds
+        var size = contentBounds
+        if let viewportHeight = collectionView?.bounds.height, viewportHeight > 0 {
+            size.height = min(size.height, viewportHeight)
+        }
+        return size
     }
     
     /// Returns cached attributes for elements in the visible rect

--- a/platforms/ios/AGenUI/Classes/Render/Component/Impl/TextComponent.swift
+++ b/platforms/ios/AGenUI/Classes/Render/Component/Impl/TextComponent.swift
@@ -6,6 +6,24 @@
 //
 
 import UIKit
+import CoreText
+
+// MARK: - Custom Attribute Key
+
+extension NSAttributedString.Key {
+    /// Custom decoration attribute, value is TextDecorationConfigBox
+    /// Used only for custom Core Graphics drawing of .dashed style
+    static let customDecoration = NSAttributedString.Key("CustomTextDecorationAttributeName")
+}
+
+/// Box wrapper for storing TextDecorationConfig in NSAttributedString (requires ObjC object)
+private class TextDecorationConfigBox: NSObject {
+    let config: TextDecorationConfig
+    init(_ config: TextDecorationConfig) {
+        self.config = config
+        super.init()
+    }
+}
 
 // MARK: - Text Decoration Configuration (W3C Standard)
 
@@ -29,24 +47,33 @@ enum TextDecorationStyle: String {
 /// Text decoration configuration (W3C compliant)
 struct TextDecorationConfig {
     /// Decoration line position
-    var line: TextDecorationLine = .underline
+    var line: TextDecorationLine = .none
     /// Decoration line style
     var style: TextDecorationStyle = .solid
     /// Decoration line color
-    var color: UIColor = .black
+    var color: UIColor? = nil
     /// Decoration line thickness (W3C text-decoration-thickness)
     var thickness: CGFloat = 1.0
+    /// Dashed line segment width (only for .dashed style, default 2)
+    var dashWidth: CGFloat = 2
+    /// Dashed line gap width (only for .dashed style, default 1.5)
+    var dashGap: CGFloat = 1.5
+    /// Extra underline offset from baseline position (default 1)
+    var offset: CGFloat = 1
     
     /// Parse from CSS style dictionary
     static func from(styles: [String: Any]) -> TextDecorationConfig? {
         var config = TextDecorationConfig()
-        var hasDecoration = false
+        
+        // Parse shorthand property text-decoration
+        if let decoration = styles["text-decoration"] as? String {
+            parseTextDecoration(decoration, into: &config)
+        }
         
         // Parse text-decoration-line
         if let lineValue = styles["text-decoration-line"] as? String {
             if let line = TextDecorationLine(rawValue: lineValue.lowercased()) {
                 config.line = line
-                hasDecoration = true
             }
         }
         
@@ -54,7 +81,6 @@ struct TextDecorationConfig {
         if let styleValue = styles["text-decoration-style"] as? String {
             if let style = TextDecorationStyle(rawValue: styleValue.lowercased()) {
                 config.style = style
-                hasDecoration = true
             }
         }
         
@@ -63,49 +89,40 @@ struct TextDecorationConfig {
             let parsedColor = CSSPropertyParser.parseColor(colorValue)
             if case .color(let value) = parsedColor {
                 config.color = value
-                hasDecoration = true
             }
         }
         
         // Parse text-decoration-thickness
         if let thicknessValue = styles["text-decoration-thickness"] as? String {
-            if let thickness = parseLength(thicknessValue) {
+            if let thickness = parseLength(thicknessValue), thickness > 0 {
                 config.thickness = thickness
-                hasDecoration = true
             }
-        } else if let thicknessValue = styles["text-decoration-thickness"] as? CGFloat {
-            config.thickness = thicknessValue
-            hasDecoration = true
+        } else if let thicknessValue = styles["text-decoration-thickness"] as? CGFloat, thicknessValue > 0 {
+            config.thickness = thicknessValue * Component.BS_POINT_SCALE
         }
         
-        // Parse shorthand property text-decoration
-        if let decoration = styles["text-decoration"] as? String {
-            parseTextDecoration(decoration, into: &config)
-            hasDecoration = true
-        }
-        
-        return hasDecoration ? config : nil
+        return config.line != TextDecorationLine.none ? config : nil
     }
     
-    /// Parse text-decoration shorthand property
+    /// Parse text-decoration shorthand property (positional format, aligned with Android)
+    /// Format: "line style color" (e.g. "underline dashed #FF0000")
+    /// - parts[0]: line type (underline, line-through, overline, none)
+    /// - parts[1]: style (solid, dashed, dotted, double, wavy)
+    /// - parts[2]: color (#hex or rgb)
     private static func parseTextDecoration(_ value: String, into config: inout TextDecorationConfig) {
         let parts = value.lowercased().split(separator: " ").map { String($0) }
-        
-        for part in parts {
-            // Try parsing as line
-            if let line = TextDecorationLine(rawValue: part) {
-                config.line = line
-            }
-            // Try parsing as style
-            else if let style = TextDecorationStyle(rawValue: part) {
-                config.style = style
-            }
-            // Try parsing as color
-            else if part.hasPrefix("#") || part.hasPrefix("rgb") {
-                let parsedColor = CSSPropertyParser.parseColor(part)
-                if case .color(let value) = parsedColor {
-                    config.color = value
-                }
+
+        // Positional parsing: parts[0]=line, parts[1]=style, parts[2]=color
+        if parts.count >= 1, let line = TextDecorationLine(rawValue: parts[0]) {
+            config.line = line
+        }
+        if parts.count >= 2, let style = TextDecorationStyle(rawValue: parts[1]) {
+            config.style = style
+        }
+        if parts.count >= 3 {
+            let parsedColor = CSSPropertyParser.parseColor(parts[2])
+            if case .color(let colorValue) = parsedColor {
+                config.color = colorValue
             }
         }
     }
@@ -117,7 +134,7 @@ struct TextDecorationConfig {
             .trimmingCharacters(in: .whitespaces)
         
         if let number = Double(cleanValue) {
-            return CGFloat(number)
+            return CGFloat(number) * Component.BS_POINT_SCALE
         }
         return nil
     }
@@ -177,8 +194,9 @@ class TextDecorationLabel: UILabel {
         let paragraphStyle: NSMutableParagraphStyle
         if let existingAttributedText = super.attributedText,
            existingAttributedText.length > 0,
-           let existingStyle = existingAttributedText.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle {
-            paragraphStyle = existingStyle.mutableCopy() as! NSMutableParagraphStyle
+           let existingStyle = existingAttributedText.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle,
+           let mutableStyle = existingStyle.mutableCopy() as? NSMutableParagraphStyle {
+            paragraphStyle = mutableStyle
         } else {
             paragraphStyle = NSMutableParagraphStyle()
             // Keep current alignment
@@ -197,6 +215,11 @@ class TextDecorationLabel: UILabel {
     
     /// Create decoration attributes
     private func createDecorationAttributes(config: TextDecorationConfig) -> [NSAttributedString.Key: Any] {
+        // .dashed uses custom Core Graphics drawing, no NSUnderlineStyle set
+        if config.style == .dashed && config.line != .none {
+            return [.customDecoration: TextDecorationConfigBox(config)]
+        }
+
         var attributes: [NSAttributedString.Key: Any] = [:]
         
         // Set decoration line style
@@ -239,6 +262,135 @@ class TextDecorationLabel: UILabel {
         }
         
         return attributes
+    }
+
+    // MARK: - Custom Dashed Underline Drawing
+
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        drawDashedUnderlines(in: rect)
+    }
+
+    private func drawDashedUnderlines(in rect: CGRect) {
+        guard let attributedText = attributedText,
+              attributedText.length > 0 else { return }
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+
+        // Find decoration config early — bail out if not dashed
+        guard let box = attributedText.attribute(.customDecoration, at: 0, effectiveRange: nil) as? TextDecorationConfigBox else { return }
+        let config = box.config
+        guard config.style == .dashed else { return }
+
+        // Use NSLayoutManager to get per-line geometry directly.
+        // Each lineFragmentRect already contains the correct Y origin and height
+        // as computed by TextKit, so we don't need to manually derive perLineHeight,
+        // lineCount, or verticalOffset.
+        let lm = NSLayoutManager()
+        let tc = NSTextContainer(size: CGSize(width: self.bounds.width, height: .greatestFiniteMagnitude))
+        tc.lineFragmentPadding = 0
+        tc.maximumNumberOfLines = numberOfLines
+        tc.lineBreakMode = .byWordWrapping
+
+        let fixedString = NSMutableAttributedString(attributedString: attributedText)
+        let fixRange = NSRange(location: 0, length: fixedString.length)
+        fixedString.enumerateAttribute(.paragraphStyle, in: fixRange, options: []) { value, range, _ in
+            if let ps = value as? NSParagraphStyle {
+                if let mutable = ps.mutableCopy() as? NSMutableParagraphStyle {
+                    mutable.lineBreakMode = .byWordWrapping
+                    fixedString.addAttribute(.paragraphStyle, value: mutable, range: range)
+                }
+            }
+        }
+        let ts = NSTextStorage(attributedString: fixedString)
+        ts.addLayoutManager(lm)
+        lm.addTextContainer(tc)
+        lm.ensureLayout(for: tc)
+        let glyphRange = lm.glyphRange(for: tc)
+
+        var lineInfos: [(lineRect: CGRect, usedRect: CGRect, textRect: CGRect)] = []
+        lm.enumerateLineFragments(forGlyphRange: glyphRange) {
+            lineFragmentRect, usedRect, container, lineGlyphRange, _ in
+            let textRect = lm.boundingRect(forGlyphRange: lineGlyphRange, in: container)
+            lineInfos.append((lineFragmentRect, usedRect, textRect))
+        }
+
+        guard !lineInfos.isEmpty else { return }
+
+        let font = attributedText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        // Read baselineOffset directly from attributed string (set by buildAttributedText
+        // as half-leading = (targetLineHeight - font.lineHeight) / 2).
+        // No need to manually compute halfLeading from perLineHeight.
+        let baselineOffset = (attributedText.attribute(.baselineOffset, at: 0, effectiveRange: nil) as? CGFloat) ?? 0
+        let color = (config.color != nil) ? config.color : textColor
+        let dashWidth = config.dashWidth
+        let dashGap = config.dashGap
+        let underlineHeight = config.thickness
+        let underlineOffset = config.offset
+        let strokeHalf = underlineHeight / 2.0
+
+        let defaultOffset: CGFloat = {
+            let base = underlineHeight * 2.0
+            if let font = font { return max(base, abs(font.descender) - strokeHalf) }
+            return base
+        }()
+        // Draw one dashed decoration per line fragment from NSLayoutManager.
+        // lineFragmentRect already has the correct Y origin and height from TextKit,
+        // and baselineOffset encodes the half-leading centering — no manual perLineHeight needed.
+        for (_, info) in lineInfos.enumerated() {
+            let lineRect = info.lineRect
+            let lineTop = lineRect.minY
+            let lineBottom = lineRect.maxY
+            let lineHeight = lineRect.height
+
+            // Compute Y offset relative to baseline based on decoration line position:
+            //   .underline   — below baseline (default)
+            //   .lineThrough — at x-height center (~1/3 of ascender above baseline)
+            //   .overline    — above ascender
+            let lineYOffset: CGFloat
+            switch config.line {
+            case .underline:
+                lineYOffset = defaultOffset + underlineOffset
+            case .lineThrough:
+                // Strikethrough sits at roughly 1/3 of ascender height above baseline
+                lineYOffset = -(font?.ascender ?? lineHeight) * 0.3
+            case .overline:
+                // Above the ascender: move up by ascender height, add strokeHalf to keep stroke within bounds
+                lineYOffset = -(font?.ascender ?? lineHeight * 0.8) + strokeHalf
+            case .none:
+                lineYOffset = 0
+            }
+            // Baseline position within the line fragment:
+            //   lineTop + ascender (natural baseline) + baselineOffset (half-leading shift)
+            let baselineY = lineTop + (font?.ascender ?? lineHeight * 0.8) + baselineOffset
+            let y = baselineY + lineYOffset
+
+            // Cap Y to stay within the line fragment
+            let descenderBottom = baselineY + abs(font?.descender ?? 0)
+            let maxY = min(lineBottom - strokeHalf, descenderBottom + 1.0)
+            let minY = lineTop + strokeHalf
+            let cappedY = min(max(y, minY), maxY)
+
+            // X: use per-line usedRect (the actual used portion of each line fragment)
+            // instead of boundingRect which can overshoot with negative baselineOffset.
+            let drawMinX = max(0, info.usedRect.minX)
+            let drawMaxX = min(self.bounds.width, info.usedRect.maxX)
+
+            // Skip if outside the dirty rect
+            if !CGRect(x: drawMinX - 1, y: lineTop - 1, width: drawMaxX - drawMinX + 2, height: lineHeight + 2).intersects(rect) {
+                continue
+            }
+
+            context.saveGState()
+            context.setStrokeColor(color?.cgColor ?? UIColor.black.cgColor)
+            context.setLineWidth(underlineHeight)
+            context.setLineCap(.butt)
+            context.setLineDash(phase: 0, lengths: [dashWidth, dashGap])
+            context.move(to: CGPoint(x: drawMinX, y: cappedY))
+            context.addLine(to: CGPoint(x: drawMaxX, y: cappedY))
+            context.strokePath()
+            context.restoreGState()
+        }
+
     }
 }
 
@@ -294,7 +446,7 @@ extension TextAlignment {
     
 }
 
-/// TextComponent component implementation (compliant with A2UI v0.9 protocol)
+/// TextComponent component implementation
 ///
 /// Supported properties:
 /// - text: Text content string (String)
@@ -396,9 +548,9 @@ class TextComponent: Component {
     override func updateProperties(_ properties: [String: Any]) {
         // Call parent method to apply CSS properties to self (padding, background-color, etc.)
         super.updateProperties(properties)
-        
+
         guard let label = label else { return }
-        
+
         // Handle textChunk field (content append, supports both String and numeric types)
         if let textChunkValue = properties["textChunk"] {
             let textChunk = TextComponent.extractTextValue(textChunkValue) ?? ""
@@ -414,7 +566,7 @@ class TextComponent: Component {
             label.text = text.count == 0 ? " " : text
             label.invalidateIntrinsicContentSize()
         }
-        
+
         // Update style properties
         if let styles = properties["styles"] as? [String: Any] {
             applyStyles(styles)
@@ -446,7 +598,7 @@ class TextComponent: Component {
         if let fontSizeValue = styles["font-size"] as? String {
             parsed.fontSize = extractFontSize(from: fontSizeValue)
         } else if let num = styles["font-size"] as? NSNumber {
-            parsed.fontSize = CGFloat(num.doubleValue)
+            parsed.fontSize = CGFloat(num.doubleValue) * Component.BS_POINT_SCALE
         }
 
         // Parse font-weight
@@ -631,7 +783,7 @@ class TextComponent: Component {
         let glyphCount = manager.numberOfGlyphs
         while index < glyphCount {
             var range = NSRange()
-            _ = manager.lineFragmentRect(forGlyphAt: index, effectiveRange: &range)
+            let fragRect = manager.lineFragmentRect(forGlyphAt: index, effectiveRange: &range)
             index = NSMaxRange(range)
             count += 1
         }
@@ -720,6 +872,11 @@ class TextComponent: Component {
     
     /// Build text decoration attribute dictionary (does not modify label)
     private class func buildDecorationAttributes(config: TextDecorationConfig) -> [NSAttributedString.Key: Any] {
+        // .dashed uses custom Core Graphics drawing, no NSUnderlineStyle set
+        if config.style == .dashed && config.line != .none {
+            return [.customDecoration: TextDecorationConfigBox(config)]
+        }
+
         var attributes: [NSAttributedString.Key: Any] = [:]
         
         var underlineStyle: NSUnderlineStyle = []
@@ -768,7 +925,7 @@ class TextComponent: Component {
         } else {
             // No unit or other unit: use value directly
             if let size = Double(fontSizeString) {
-                return CGFloat(size)
+                return CGFloat(size) * Component.BS_POINT_SCALE
             }
         }
         return nil
@@ -932,7 +1089,8 @@ class TextComponent: Component {
                 : CGFloat(maxHeight)
         }
 
-        return CGSize(width: measuredWidth, height: measuredHeight)
+        let result = CGSize(width: measuredWidth, height: measuredHeight)
+        return result
     }
 
     // MARK: - Shared Text Construction (used by both applyStyles and measure)

--- a/platforms/ios/AGenUI/Classes/Render/Surface/Surface.swift
+++ b/platforms/ios/AGenUI/Classes/Render/Surface/Surface.swift
@@ -111,8 +111,21 @@ import UIKit
         // Each Component's frame is set by applyLayoutFromStyles() when updateProperties() is called.
         // Without this step, surface.view always has zero height and callers cannot read the
         // rendered content height from surface.view.frame in the onLayoutChanged callback.
-        let contentWidth  = rootComponent.frame.width
-        let contentHeight = rootComponent.frame.maxY  // use maxY to include absolute-positioned children that extend below root
+        var contentWidth  = rootComponent.frame.width
+        var contentHeight = rootComponent.frame.maxY  // use maxY to include absolute-positioned children that extend below root
+
+        // Root node has no Yoga parent to consume its margin.
+        // Yoga's getLayoutLeft/Top already include margin-left/top in the
+        // position (see YGNode::setPosition), and maxY includes origin.y,
+        // so margin-top is already accounted for. Only margin-bottom/right
+        // are lost — add them here.
+        if let styles = rootComponent.properties["styles"] as? [String: Any] {
+            let margin = CSSMarginResolver.resolve(styles)
+            // top/left already in Yoga position (frame.origin), only add bottom/right
+            contentWidth  += margin.right
+            contentHeight += margin.bottom
+        }
+
         if contentWidth > 0 || contentHeight > 0 {
             view.frame = CGRect(x: view.frame.origin.x,
                                 y: view.frame.origin.y,

--- a/playground/harmony/entry/src/main/resources/rawfile/stories/A2UI Show/AudioPlayer/updateComponents.json
+++ b/playground/harmony/entry/src/main/resources/rawfile/stories/A2UI Show/AudioPlayer/updateComponents.json
@@ -1,12 +1,4807 @@
 {
   "version": "v0.9",
   "updateComponents": {
-    "surfaceId": "audio_demo",
+    "surfaceId": "homefeed",
+    "designWidth": 750,
     "components": [
       {
         "id": "root",
-        "component": "AudioPlayer",
-        "url": "https://download.samplelib.com/mp3/sample-3s.mp3"
+        "component": "Column",
+        "children": [
+          "tc-root",
+          "sl-root",
+          "rc-grid"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "16px",
+          "background-color": "#F5F5F5"
+        }
+      },
+      {
+        "id": "tc-root",
+        "component": "Row",
+        "children": [
+          "tc-card-left",
+          "tc-card-right"
+        ],
+        "align": "stretch",
+        "justify": "spaceBetween",
+        "styles": {
+          "width": "726px"
+        }
+      },
+      {
+        "id": "tc-card-left",
+        "component": "Column",
+        "children": [
+          "tc-left-title-row",
+          "tc-left-content-row"
+        ],
+        "styles": {
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "padding": "20px",
+          "width": "350px"
+        }
+      },
+      {
+        "id": "tc-left-title-row",
+        "component": "Row",
+        "children": [
+          "tc-left-title"
+        ],
+        "align": "center"
+      },
+      {
+        "id": "tc-left-title",
+        "component": "Text",
+        "text": "热门商品",
+        "variant": "h1",
+        "styles": {
+          "font-size": "26px",
+          "font-weight": "bold",
+          "color": "rgba(0,0,0,0.87)"
+        }
+      },
+      {
+        "id": "tc-left-content-row",
+        "component": "Row",
+        "children": [
+          "tc-left-text-col",
+          "tc-left-img"
+        ],
+        "justify": "spaceBetween",
+        "align": "center"
+      },
+      {
+        "id": "tc-left-text-col",
+        "component": "Column",
+        "children": [
+          "tc-left-subtitle",
+          "tc-left-count-row",
+          "tc-left-tip"
+        ],
+        "styles": {
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "tc-left-subtitle",
+        "component": "Text",
+        "text": "低价货源",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.4)"
+        }
+      },
+      {
+        "id": "tc-left-count-row",
+        "component": "Row",
+        "children": [
+          "tc-left-count",
+          "tc-left-unit"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "tc-left-count",
+        "component": "Text",
+        "text": "10",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "rgba(0,0,0,0.87)"
+        }
+      },
+      {
+        "id": "tc-left-unit",
+        "component": "Text",
+        "text": "款",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.4)"
+        }
+      },
+      {
+        "id": "tc-left-tip",
+        "component": "Text",
+        "text": "去查看",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.4)"
+        }
+      },
+      {
+        "id": "tc-left-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01UVOvP426XNJIBrJdT_!!2219548817671-0-cib.jpg",
+        "styles": {
+          "width": "116px",
+          "height": "116px",
+          "border-radius": "8px"
+        }
+      },
+      {
+        "id": "tc-card-right",
+        "component": "Column",
+        "children": [
+          "tc-right-title-row",
+          "tc-right-content-row"
+        ],
+        "styles": {
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "padding": "20px",
+          "width": "350px"
+        }
+      },
+      {
+        "id": "tc-right-title-row",
+        "component": "Row",
+        "children": [
+          "tc-right-title"
+        ],
+        "align": "center"
+      },
+      {
+        "id": "tc-right-title",
+        "component": "Text",
+        "text": "快速出单",
+        "styles": {
+          "font-size": "26px",
+          "font-weight": "bold",
+          "color": "rgba(0,0,0,0.87)"
+        }
+      },
+      {
+        "id": "tc-right-content-row",
+        "component": "Row",
+        "children": [
+          "tc-right-text-col",
+          "tc-right-img"
+        ],
+        "justify": "spaceBetween",
+        "align": "center"
+      },
+      {
+        "id": "tc-right-text-col",
+        "component": "Column",
+        "children": [
+          "tc-right-subtitle",
+          "tc-right-count-row",
+          "tc-right-tip"
+        ],
+        "styles": {
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "tc-right-subtitle",
+        "component": "Text",
+        "text": "老商上新",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.4)"
+        }
+      },
+      {
+        "id": "tc-right-count-row",
+        "component": "Row",
+        "children": [
+          "tc-right-count",
+          "tc-right-unit"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "tc-right-count",
+        "component": "Text",
+        "text": "8",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "rgba(0,0,0,0.87)"
+        }
+      },
+      {
+        "id": "tc-right-unit",
+        "component": "Text",
+        "text": "款",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.4)"
+        }
+      },
+      {
+        "id": "tc-right-tip",
+        "component": "Text",
+        "text": "去查看",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.4)"
+        }
+      },
+      {
+        "id": "tc-right-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN011ZD63Q26XNJUfueYW_!!2219548817671-0-cib.jpg",
+        "styles": {
+          "width": "116px",
+          "height": "116px",
+          "border-radius": "8px"
+        }
+      },
+      {
+        "id": "sl-root",
+        "component": "List",
+        "direction": "horizontal",
+        "children": [
+          "sl-item-0",
+          "sl-item-1",
+          "sl-item-2",
+          "sl-item-3",
+          "sl-item-4",
+          "sl-item-5",
+          "sl-item-6",
+          "sl-item-7",
+          "sl-item-8",
+          "sl-item-9",
+          "sl-item-10",
+          "sl-item-11"
+        ],
+        "styles": {
+          "width": "726px",
+          "height": "136px",
+          "background-color": "#FFFFFF",
+          "border-radius": "8px",
+          "padding": "16px 0 24px 0",
+          "margin-top": "12px",
+          "margin-bottom": "12px",
+          "overflow": "scroll"
+        }
+      },
+      {
+        "id": "sl-item-0",
+        "component": "Column",
+        "children": [
+          "sl-img-0",
+          "sl-text-0"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-0",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i4/O1CN01cuclbI1Hq751oMCaZ_!!6000000000808-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-0",
+        "component": "Text",
+        "text": "服饰上新",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-1",
+        "component": "Column",
+        "children": [
+          "sl-img-1",
+          "sl-text-1"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-1",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i3/O1CN01zA865n1BvFpcQr3Yg_!!6000000000007-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-1",
+        "component": "Text",
+        "text": "热卖榜",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-2",
+        "component": "Column",
+        "children": [
+          "sl-img-2",
+          "sl-text-2"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-2",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i1/O1CN01Ql3BlQ1LMa0HqNCXV_!!6000000001285-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-2",
+        "component": "Text",
+        "text": "元宝工厂",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-3",
+        "component": "Column",
+        "children": [
+          "sl-img-3",
+          "sl-text-3"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-3",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i3/O1CN01RKLgJC1uu1Tb5GyZF_!!6000000006096-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-3",
+        "component": "Text",
+        "text": "跨境专供",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-4",
+        "component": "Column",
+        "children": [
+          "sl-img-4",
+          "sl-text-4"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-4",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i2/O1CN01kjeBfb1gJvdub89cq_!!6000000004122-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-4",
+        "component": "Text",
+        "text": "直播",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-5",
+        "component": "Column",
+        "children": [
+          "sl-img-5",
+          "sl-text-5"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-5",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i3/O1CN01xKqoOy1WrEHZaYhPL_!!6000000002841-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-5",
+        "component": "Text",
+        "text": "哇噢定制",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-6",
+        "component": "Column",
+        "children": [
+          "sl-img-6",
+          "sl-text-6"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-6",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i1/O1CN01XvNqkY1rKoB1GZryz_!!6000000005613-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-6",
+        "component": "Text",
+        "text": "一件代发",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-7",
+        "component": "Column",
+        "children": [
+          "sl-img-7",
+          "sl-text-7"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-7",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i1/O1CN01IZ90KO23nujg4ZZFc_!!6000000007301-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-7",
+        "component": "Text",
+        "text": "会员店",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-8",
+        "component": "Column",
+        "children": [
+          "sl-img-8",
+          "sl-text-8"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-8",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i3/O1CN01OIFpO31GAbZOFICHb_!!6000000000582-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-8",
+        "component": "Text",
+        "text": "行家选",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-9",
+        "component": "Column",
+        "children": [
+          "sl-img-9",
+          "sl-text-9"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-9",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i2/O1CN01GfVRv51n8CobUL0fd_!!6000000005044-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-9",
+        "component": "Text",
+        "text": "必采好店",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-10",
+        "component": "Column",
+        "children": [
+          "sl-img-10",
+          "sl-text-10"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-10",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i3/O1CN01jhIRSp1gteXGjHpEx_!!6000000004200-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-10",
+        "component": "Text",
+        "text": "严选",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "sl-item-11",
+        "component": "Column",
+        "children": [
+          "sl-img-11",
+          "sl-text-11"
+        ],
+        "align": "center",
+        "styles": {
+          "width": "96px",
+          "height": "96px",
+          "margin": "0 8px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "sl-img-11",
+        "component": "Image",
+        "url": "https://gw.alicdn.com/imgextra/i3/O1CN013YeN1I1KD8Da7vA51_!!6000000001129-2-tps-136-136.png",
+        "styles": {
+          "width": "68px",
+          "height": "68px"
+        }
+      },
+      {
+        "id": "sl-text-11",
+        "component": "Text",
+        "text": "小店进货",
+        "styles": {
+          "font-size": "22px",
+          "color": "rgba(0,0,0,0.6)",
+          "text-align": "center"
+        }
+      },
+      {
+        "id": "rc-grid",
+        "component": "Row",
+        "children": [
+          "rc-col-left",
+          "rc-col-right"
+        ],
+        "align": "start",
+        "justify": "spaceBetween",
+        "styles": {
+          "width": "726px",
+          "margin-top": "16px"
+        }
+      },
+      {
+        "id": "rc-col-left",
+        "component": "Column",
+        "children": [
+          "rc-0",
+          "rc-2",
+          "rc-4",
+          "rc-6",
+          "rc-8",
+          "rc-10",
+          "rc-12",
+          "rc-14",
+          "rc-16",
+          "rc-18",
+          "rc-20",
+          "rc-22",
+          "rc-24"
+        ],
+        "styles": {
+          "width": "350px"
+        }
+      },
+      {
+        "id": "rc-col-right",
+        "component": "Column",
+        "children": [
+          "rc-1",
+          "rc-3",
+          "rc-5",
+          "rc-7",
+          "rc-9",
+          "rc-11",
+          "rc-13",
+          "rc-15",
+          "rc-17",
+          "rc-19",
+          "rc-21",
+          "rc-23"
+        ],
+        "styles": {
+          "width": "350px"
+        }
+      },
+      {
+        "id": "rc-0",
+        "component": "Column",
+        "children": [
+          "rc-0-img",
+          "rc-0-body",
+          "rc-0-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-0-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN010WRV4u22EopESzho5_!!2218127267089-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-0-body",
+        "component": "Column",
+        "children": [
+          "rc-0-title-row",
+          "rc-0-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-0-title-row",
+        "component": "Row",
+        "children": [
+          "rc-0-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-0-title",
+        "component": "Text",
+        "text": "10套便利店调酒套餐组合装威士忌伏特加小瓶鸡尾酒摆摊夜市批发",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-0-price-row",
+        "component": "Row",
+        "children": [
+          "rc-0-price-sym",
+          "rc-0-price-int",
+          "rc-0-price-dec",
+          "rc-0-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-0-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-0-price-int",
+        "component": "Text",
+        "text": "79",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-0-price-dec",
+        "component": "Text",
+        "text": ".9",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-0-sales",
+        "component": "Text",
+        "text": "售40+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-0-tag0",
+        "component": "Text",
+        "text": "回头率28%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-0-tag1",
+        "component": "Text",
+        "text": "80+人收藏",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-0-footer",
+        "component": "Row",
+        "children": [
+          "rc-0-tag0",
+          "rc-0-tag1"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-1",
+        "component": "Column",
+        "children": [
+          "rc-1-img",
+          "rc-1-body",
+          "rc-1-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-1-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01Yg09Kq1izGdJxvM08_!!966824483-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-1-body",
+        "component": "Column",
+        "children": [
+          "rc-1-title-row",
+          "rc-1-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-1-title-row",
+        "component": "Row",
+        "children": [
+          "rc-1-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-1-title",
+        "component": "Text",
+        "text": "跨境新款无刷手电钻双速锂电钻多功能电动螺丝刀电动工具套装组合",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-1-price-row",
+        "component": "Row",
+        "children": [
+          "rc-1-price-sym",
+          "rc-1-price-int",
+          "rc-1-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-1-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-1-price-int",
+        "component": "Text",
+        "text": "70",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-1-sales",
+        "component": "Text",
+        "text": "售2500+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-1-tag0",
+        "component": "Text",
+        "text": "明天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-1-tag1",
+        "component": "Text",
+        "text": "回头率43%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-1-tag2",
+        "component": "Text",
+        "text": "7*24小时响应",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-1-footer",
+        "component": "Row",
+        "children": [
+          "rc-1-tag0",
+          "rc-1-tag1",
+          "rc-1-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-2",
+        "component": "Column",
+        "children": [
+          "rc-2-img",
+          "rc-2-body",
+          "rc-2-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-2-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01tVNQvX1yZBtdYpZZU_!!2212755646592-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-2-body",
+        "component": "Column",
+        "children": [
+          "rc-2-title-row",
+          "rc-2-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-2-title-row",
+        "component": "Row",
+        "children": [
+          "rc-2-icon-0",
+          "rc-2-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-2-title",
+        "component": "Text",
+        "text": "厂家批发复古红蝴蝶车载香薰车内饰品摆件汽车中控台装饰扩香石女",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-2-price-row",
+        "component": "Row",
+        "children": [
+          "rc-2-price-sym",
+          "rc-2-price-int",
+          "rc-2-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-2-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-2-price-int",
+        "component": "Text",
+        "text": "26",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-2-sales",
+        "component": "Text",
+        "text": "售200+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-2-tag0",
+        "component": "Text",
+        "text": "后天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-2-tag1",
+        "component": "Text",
+        "text": "回头率73%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-2-tag2",
+        "component": "Text",
+        "text": "7天无理由",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-2-footer",
+        "component": "Row",
+        "children": [
+          "rc-2-tag0",
+          "rc-2-tag1",
+          "rc-2-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-3",
+        "component": "Column",
+        "children": [
+          "rc-3-img",
+          "rc-3-body",
+          "rc-3-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-3-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01bJajJI1mCxMFbfPum_!!2850054919-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-3-body",
+        "component": "Column",
+        "children": [
+          "rc-3-title-row",
+          "rc-3-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-3-title-row",
+        "component": "Row",
+        "children": [
+          "rc-3-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-3-title",
+        "component": "Text",
+        "text": "一体式裙摆款沙发套万能弹力沙发罩全包通用跨境沙发套罩亚马逊跨",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-3-price-row",
+        "component": "Row",
+        "children": [
+          "rc-3-price-sym",
+          "rc-3-price-int",
+          "rc-3-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-3-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-3-price-int",
+        "component": "Text",
+        "text": "55",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-3-sales",
+        "component": "Text",
+        "text": "售700+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-3-tag0",
+        "component": "Text",
+        "text": "回头率56%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-3-tag1",
+        "component": "Text",
+        "text": "7天无理由",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-3-footer",
+        "component": "Row",
+        "children": [
+          "rc-3-tag0",
+          "rc-3-tag1"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-4",
+        "component": "Column",
+        "children": [
+          "rc-4-img",
+          "rc-4-body",
+          "rc-4-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-4-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01GQnw7m1XF2tJuT65M_!!2218241792893-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-4-body",
+        "component": "Column",
+        "children": [
+          "rc-4-title-row",
+          "rc-4-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-4-title-row",
+        "component": "Row",
+        "children": [
+          "rc-4-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-4-title",
+        "component": "Text",
+        "text": "【加工定制】跨境爆款欧美大码组文胸聚拢上托女士内衣裹胸现货",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-4-price-row",
+        "component": "Row",
+        "children": [
+          "rc-4-price-sym",
+          "rc-4-price-int",
+          "rc-4-price-dec"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-4-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-4-price-int",
+        "component": "Text",
+        "text": "15",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-4-price-dec",
+        "component": "Text",
+        "text": ".5",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-4-tag0",
+        "component": "Text",
+        "text": "回头率69%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-4-tag1",
+        "component": "Text",
+        "text": "70+人收藏",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-4-footer",
+        "component": "Row",
+        "children": [
+          "rc-4-tag0",
+          "rc-4-tag1"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-5",
+        "component": "Column",
+        "children": [
+          "rc-5-img",
+          "rc-5-body",
+          "rc-5-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-5-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01nQEjcA1hyypQ8YPoU_!!2216994544347-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-5-body",
+        "component": "Column",
+        "children": [
+          "rc-5-title-row",
+          "rc-5-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-5-title-row",
+        "component": "Row",
+        "children": [
+          "rc-5-icon-0",
+          "rc-5-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-5-title",
+        "component": "Text",
+        "text": "【粉桃魔眼】温柔裸粉幻彩钻饰爱心穿戴甲甜妹显白清透氛围感美甲",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-5-price-row",
+        "component": "Row",
+        "children": [
+          "rc-5-price-sym",
+          "rc-5-price-int",
+          "rc-5-price-dec",
+          "rc-5-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-5-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-5-price-int",
+        "component": "Text",
+        "text": "13",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-5-price-dec",
+        "component": "Text",
+        "text": ".9",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-5-sales",
+        "component": "Text",
+        "text": "售300+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-5-tag0",
+        "component": "Text",
+        "text": "风格上新",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC53E4",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-5-tag1",
+        "component": "Text",
+        "text": "甜妹显白清透",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC53E4",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-5-tag2",
+        "component": "Text",
+        "text": "明天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-5-footer",
+        "component": "Row",
+        "children": [
+          "rc-5-tag0",
+          "rc-5-tag1",
+          "rc-5-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-6",
+        "component": "Column",
+        "children": [
+          "rc-6-img",
+          "rc-6-body",
+          "rc-6-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-6-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01fFkDcu1qmSVH5R7eG_!!4611686018427381058-0-item_pic.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-6-body",
+        "component": "Column",
+        "children": [
+          "rc-6-title-row",
+          "rc-6-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-6-title-row",
+        "component": "Row",
+        "children": [
+          "rc-6-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-6-title",
+        "component": "Text",
+        "text": "法式高级感沙发垫四季通用2026新款异形防滑坐垫直排防猫抓盖布巾",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-6-price-row",
+        "component": "Row",
+        "children": [
+          "rc-6-price-sym",
+          "rc-6-price-int",
+          "rc-6-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-6-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-6-price-int",
+        "component": "Text",
+        "text": "21",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-6-sales",
+        "component": "Text",
+        "text": "售200+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-6-tag0",
+        "component": "Text",
+        "text": "后天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-6-tag1",
+        "component": "Text",
+        "text": "回头率46%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-6-tag2",
+        "component": "Text",
+        "text": "包邮",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-6-footer",
+        "component": "Row",
+        "children": [
+          "rc-6-tag0",
+          "rc-6-tag1",
+          "rc-6-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-7",
+        "component": "Column",
+        "children": [
+          "rc-7-img",
+          "rc-7-body",
+          "rc-7-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-7-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01fYsLRi1ygWKlZKnK4_!!4222766608-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-7-body",
+        "component": "Column",
+        "children": [
+          "rc-7-title-row",
+          "rc-7-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-7-title-row",
+        "component": "Row",
+        "children": [
+          "rc-7-icon-0",
+          "rc-7-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-7-title",
+        "component": "Text",
+        "text": "诸暨珍珠批发天然淡水珍珠耳钉时尚微镶锆石流星气质珍珠耳饰饰品",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-7-price-row",
+        "component": "Row",
+        "children": [
+          "rc-7-price-sym",
+          "rc-7-price-int",
+          "rc-7-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-7-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-7-price-int",
+        "component": "Text",
+        "text": "20",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-7-sales",
+        "component": "Text",
+        "text": "售1200+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-7-tag0",
+        "component": "Text",
+        "text": "工艺上新",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC53E4",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-7-tag1",
+        "component": "Text",
+        "text": "合金镶锆显贵",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC53E4",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-7-tag2",
+        "component": "Text",
+        "text": "官方验货",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-7-footer",
+        "component": "Row",
+        "children": [
+          "rc-7-tag0",
+          "rc-7-tag1",
+          "rc-7-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-8",
+        "component": "Column",
+        "children": [
+          "rc-8-img",
+          "rc-8-body",
+          "rc-8-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-8-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01TfL6xj1UTkmFzr0mA_!!2217750562519-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-8-body",
+        "component": "Column",
+        "children": [
+          "rc-8-title-row",
+          "rc-8-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-8-title-row",
+        "component": "Row",
+        "children": [
+          "rc-8-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-8-title",
+        "component": "Text",
+        "text": "折叠电脑桌卧室家用书桌一体靠墙长桌子简易款出租屋新型窄木桌子",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-8-price-row",
+        "component": "Row",
+        "children": [
+          "rc-8-price-sym",
+          "rc-8-price-int",
+          "rc-8-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-8-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-8-price-int",
+        "component": "Text",
+        "text": "238",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-8-sales",
+        "component": "Text",
+        "text": "1件起批",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-8-tag0",
+        "component": "Text",
+        "text": "3天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-8-tag1",
+        "component": "Text",
+        "text": "回头率49%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-8-tag2",
+        "component": "Text",
+        "text": "7天无理由",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-8-footer",
+        "component": "Row",
+        "children": [
+          "rc-8-tag0",
+          "rc-8-tag1",
+          "rc-8-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-9",
+        "component": "Column",
+        "children": [
+          "rc-9-img",
+          "rc-9-body"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-9-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01Wt9j7B2NZWYZUhwpZ_!!954979977-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-9-body",
+        "component": "Column",
+        "children": [
+          "rc-9-title-row",
+          "rc-9-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-9-title-row",
+        "component": "Row",
+        "children": [
+          "rc-9-icon-0",
+          "rc-9-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-9-title",
+        "component": "Text",
+        "text": "哇噢定 制新款多功能免安装 保护隐私蚊帐休闲帐篷出差户外便携带",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-9-price-row",
+        "component": "Row",
+        "children": [
+          "rc-9-price-sym",
+          "rc-9-price-int",
+          "rc-9-price-dec",
+          "rc-9-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-9-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-9-price-int",
+        "component": "Text",
+        "text": "57",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-9-price-dec",
+        "component": "Text",
+        "text": ".8",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-9-sales",
+        "component": "Text",
+        "text": "售200+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-10",
+        "component": "Column",
+        "children": [
+          "rc-10-img",
+          "rc-10-body"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-10-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01OU8hIT2HBLpzvjc0q_!!3070349112-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-10-body",
+        "component": "Column",
+        "children": [
+          "rc-10-title-row",
+          "rc-10-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-10-title-row",
+        "component": "Row",
+        "children": [
+          "rc-10-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-10-title",
+        "component": "Text",
+        "text": "飘窗柜储物柜落地可坐式柜子卧室地柜矮柜家用阳台收纳置物榻榻米",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-10-price-row",
+        "component": "Row",
+        "children": [
+          "rc-10-price-sym",
+          "rc-10-price-int",
+          "rc-10-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-10-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-10-price-int",
+        "component": "Text",
+        "text": "98",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-10-sales",
+        "component": "Text",
+        "text": "售200+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-11",
+        "component": "Column",
+        "children": [
+          "rc-11-img",
+          "rc-11-body",
+          "rc-11-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-11-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01bJVQrh1fujuEJ6Jzv_!!6000000004067-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-11-body",
+        "component": "Column",
+        "children": [
+          "rc-11-title-row",
+          "rc-11-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-11-title-row",
+        "component": "Row",
+        "children": [
+          "rc-11-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-11-title",
+        "component": "Text",
+        "text": "红薯同款创意网红家具板式DIY贝壳椅子莲花茶几拼接切割材料包",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-11-price-row",
+        "component": "Row",
+        "children": [
+          "rc-11-price-sym",
+          "rc-11-price-int",
+          "rc-11-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-11-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-11-price-int",
+        "component": "Text",
+        "text": "126",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-11-sales",
+        "component": "Text",
+        "text": "1件起批",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-11-tag0",
+        "component": "Text",
+        "text": "回头率66%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-11-tag1",
+        "component": "Text",
+        "text": "包邮",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-11-footer",
+        "component": "Row",
+        "children": [
+          "rc-11-tag0",
+          "rc-11-tag1"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-12",
+        "component": "Column",
+        "children": [
+          "rc-12-img",
+          "rc-12-body",
+          "rc-12-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-12-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN010RHxAq1L13QZndJ2L_!!2219806881238-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-12-body",
+        "component": "Column",
+        "children": [
+          "rc-12-title-row",
+          "rc-12-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-12-title-row",
+        "component": "Row",
+        "children": [
+          "rc-12-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-12-title",
+        "component": "Text",
+        "text": "桌下理线器收纳盒子桌底免打孔悬挂式储物架电源线槽线路整理盒子",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-12-price-row",
+        "component": "Row",
+        "children": [
+          "rc-12-price-sym",
+          "rc-12-price-int",
+          "rc-12-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-12-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-12-price-int",
+        "component": "Text",
+        "text": "31",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-12-sales",
+        "component": "Text",
+        "text": "售60+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-12-tag0",
+        "component": "Text",
+        "text": "后天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-12-tag1",
+        "component": "Text",
+        "text": "回头率36%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-12-tag2",
+        "component": "Text",
+        "text": "7天无理由",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-12-footer",
+        "component": "Row",
+        "children": [
+          "rc-12-tag0",
+          "rc-12-tag1",
+          "rc-12-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-13",
+        "component": "Column",
+        "children": [
+          "rc-13-img",
+          "rc-13-body"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-13-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01qRehIJ282LaCyXDlc_!!2216730617874-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-13-body",
+        "component": "Column",
+        "children": [
+          "rc-13-title-row",
+          "rc-13-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-13-title-row",
+        "component": "Row",
+        "children": [
+          "rc-13-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-13-title",
+        "component": "Text",
+        "text": "法式碎花蕾丝花边三角头巾甜美可爱田园风方巾高颜值头饰爆款发饰",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-13-price-row",
+        "component": "Row",
+        "children": [
+          "rc-13-price-sym",
+          "rc-13-price-int",
+          "rc-13-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-13-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-13-price-int",
+        "component": "Text",
+        "text": "6",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-13-sales",
+        "component": "Text",
+        "text": "售300+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-14",
+        "component": "Column",
+        "children": [
+          "rc-14-img",
+          "rc-14-body",
+          "rc-14-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-14-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN0127GukJ1FnFPBYlIQc_!!2220822120531-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-14-body",
+        "component": "Column",
+        "children": [
+          "rc-14-title-row",
+          "rc-14-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-14-title-row",
+        "component": "Row",
+        "children": [
+          "rc-14-icon-0",
+          "rc-14-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-14-title",
+        "component": "Text",
+        "text": "一房变两房可伸缩屏风架 遮挡帘顶天立地隔断帘卧室房间叠门帘",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-14-price-row",
+        "component": "Row",
+        "children": [
+          "rc-14-price-sym",
+          "rc-14-price-int",
+          "rc-14-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-14-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-14-price-int",
+        "component": "Text",
+        "text": "24",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-14-sales",
+        "component": "Text",
+        "text": "售1.3万+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-14-tag0",
+        "component": "Text",
+        "text": "3天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-14-tag1",
+        "component": "Text",
+        "text": "回头率54%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-14-tag2",
+        "component": "Text",
+        "text": "包邮",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-14-footer",
+        "component": "Row",
+        "children": [
+          "rc-14-tag0",
+          "rc-14-tag1",
+          "rc-14-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-15",
+        "component": "Column",
+        "children": [
+          "rc-15-img",
+          "rc-15-body",
+          "rc-15-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-15-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01aFWZLH1YQKBT5vyDj_!!2218455743053-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-15-body",
+        "component": "Column",
+        "children": [
+          "rc-15-title-row",
+          "rc-15-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-15-title-row",
+        "component": "Row",
+        "children": [
+          "rc-15-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-15-title",
+        "component": "Text",
+        "text": "84个种类透明玻璃瓶装种子墙装饰植物种子标本可收藏学习展示观察",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-15-price-row",
+        "component": "Row",
+        "children": [
+          "rc-15-price-sym",
+          "rc-15-price-int",
+          "rc-15-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-15-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-15-price-int",
+        "component": "Text",
+        "text": "310",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-15-sales",
+        "component": "Text",
+        "text": "1件起批",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-15-tag0",
+        "component": "Text",
+        "text": "后天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-15-tag1",
+        "component": "Text",
+        "text": "回头率38%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-15-tag2",
+        "component": "Text",
+        "text": "包邮",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-15-footer",
+        "component": "Row",
+        "children": [
+          "rc-15-tag0",
+          "rc-15-tag1",
+          "rc-15-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-16",
+        "component": "Column",
+        "children": [
+          "rc-16-img",
+          "rc-16-body"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-16-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN011MQWnk1zrLC9SD7d2_!!2214701816767-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-16-body",
+        "component": "Column",
+        "children": [
+          "rc-16-title-row",
+          "rc-16-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-16-title-row",
+        "component": "Row",
+        "children": [
+          "rc-16-icon-0",
+          "rc-16-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-16-title",
+        "component": "Text",
+        "text": "吊篮吊椅室内单人家用阳台秋千网篮棉绳编织藤椅流苏秋千懒人椅",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-16-price-row",
+        "component": "Row",
+        "children": [
+          "rc-16-price-sym",
+          "rc-16-price-int",
+          "rc-16-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-16-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-16-price-int",
+        "component": "Text",
+        "text": "70",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-16-sales",
+        "component": "Text",
+        "text": "售100+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-17",
+        "component": "Column",
+        "children": [
+          "rc-17-img",
+          "rc-17-body",
+          "rc-17-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-17-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01amt3DJ1JAYH8TV5eJ_!!2215616310988-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-17-body",
+        "component": "Column",
+        "children": [
+          "rc-17-title-row",
+          "rc-17-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-17-title-row",
+        "component": "Row",
+        "children": [
+          "rc-17-icon-0",
+          "rc-17-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-17-title",
+        "component": "Text",
+        "text": "ins马卡龙粉色快递袋加厚英文印刷袋出卡包装物流发货保护袋批发",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-17-price-row",
+        "component": "Row",
+        "children": [
+          "rc-17-price-sym",
+          "rc-17-price-int",
+          "rc-17-price-dec",
+          "rc-17-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-17-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-17-price-int",
+        "component": "Text",
+        "text": "0",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-17-price-dec",
+        "component": "Text",
+        "text": ".15",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-17-sales",
+        "component": "Text",
+        "text": "售10万+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-17-tag0",
+        "component": "Text",
+        "text": "3天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-17-tag1",
+        "component": "Text",
+        "text": "100+行家回购",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-17-tag2",
+        "component": "Text",
+        "text": "7天无理由",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-17-footer",
+        "component": "Row",
+        "children": [
+          "rc-17-tag0",
+          "rc-17-tag1",
+          "rc-17-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-18",
+        "component": "Column",
+        "children": [
+          "rc-18-img",
+          "rc-18-body",
+          "rc-18-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-18-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01yqwAIA22bG9YzFiMi_!!4173667138-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-18-body",
+        "component": "Column",
+        "children": [
+          "rc-18-title-row",
+          "rc-18-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-18-title-row",
+        "component": "Row",
+        "children": [
+          "rc-18-icon-0",
+          "rc-18-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-18-title",
+        "component": "Text",
+        "text": "真竹子教鞭竹根条实心竹指挥棒玩具教师教鞭竹节家用教学棍棒戒尺",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-18-price-row",
+        "component": "Row",
+        "children": [
+          "rc-18-price-sym",
+          "rc-18-price-int",
+          "rc-18-price-dec",
+          "rc-18-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-18-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-18-price-int",
+        "component": "Text",
+        "text": "5",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-18-price-dec",
+        "component": "Text",
+        "text": ".5",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-18-sales",
+        "component": "Text",
+        "text": "售2800+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-18-tag0",
+        "component": "Text",
+        "text": "官方验货",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-18-tag1",
+        "component": "Text",
+        "text": "回头率54%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-18-tag2",
+        "component": "Text",
+        "text": "7天无理由",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-18-footer",
+        "component": "Row",
+        "children": [
+          "rc-18-tag0",
+          "rc-18-tag1",
+          "rc-18-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-19",
+        "component": "Column",
+        "children": [
+          "rc-19-img",
+          "rc-19-body",
+          "rc-19-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-19-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN019kkxBD2CvXxFz9jL3_!!2212769168536-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-19-body",
+        "component": "Column",
+        "children": [
+          "rc-19-title-row",
+          "rc-19-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-19-title-row",
+        "component": "Row",
+        "children": [
+          "rc-19-icon-0",
+          "rc-19-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-19-title",
+        "component": "Text",
+        "text": "水果奶酪麻糍网红甜品糯叽叽摆摊专用即食小料夹心馅料装饰配料",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-19-price-row",
+        "component": "Row",
+        "children": [
+          "rc-19-price-sym",
+          "rc-19-price-int",
+          "rc-19-price-dec",
+          "rc-19-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-19-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-19-price-int",
+        "component": "Text",
+        "text": "12",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-19-price-dec",
+        "component": "Text",
+        "text": ".5",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-19-sales",
+        "component": "Text",
+        "text": "售200+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-19-tag0",
+        "component": "Text",
+        "text": "官方验货",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-19-tag1",
+        "component": "Text",
+        "text": "回头率66%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-19-footer",
+        "component": "Row",
+        "children": [
+          "rc-19-tag0",
+          "rc-19-tag1"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-20",
+        "component": "Column",
+        "children": [
+          "rc-20-img",
+          "rc-20-body",
+          "rc-20-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-20-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01RmPDvb2L2tCOVdDDf_!!2208366599635-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-20-body",
+        "component": "Column",
+        "children": [
+          "rc-20-title-row",
+          "rc-20-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-20-title-row",
+        "component": "Row",
+        "children": [
+          "rc-20-icon-0",
+          "rc-20-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-20-title",
+        "component": "Text",
+        "text": "奶皮子迷你糖葫芦包装袋食品级短款透明袋冷萃酸奶糖葫芦专用摆摊",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-20-price-row",
+        "component": "Row",
+        "children": [
+          "rc-20-price-sym",
+          "rc-20-price-int",
+          "rc-20-price-dec",
+          "rc-20-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-20-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-20-price-int",
+        "component": "Text",
+        "text": "9",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-20-price-dec",
+        "component": "Text",
+        "text": ".24",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-20-sales",
+        "component": "Text",
+        "text": "1件起批",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-20-tag0",
+        "component": "Text",
+        "text": "后天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-20-tag1",
+        "component": "Text",
+        "text": "回头率51%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-20-tag2",
+        "component": "Text",
+        "text": "7天无理由",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-20-footer",
+        "component": "Row",
+        "children": [
+          "rc-20-tag0",
+          "rc-20-tag1",
+          "rc-20-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-21",
+        "component": "Column",
+        "children": [
+          "rc-21-img",
+          "rc-21-body",
+          "rc-21-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-21-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN0191J18e1wzdb9EwCQ4_!!2220164786379-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-21-body",
+        "component": "Column",
+        "children": [
+          "rc-21-title-row",
+          "rc-21-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-21-title-row",
+        "component": "Row",
+        "children": [
+          "rc-21-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-21-title",
+        "component": "Text",
+        "text": "糖葫芦迷你小靶子草把子架子柱子网红迷你小串摆摊夜市展示架展示",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-21-price-row",
+        "component": "Row",
+        "children": [
+          "rc-21-price-sym",
+          "rc-21-price-int",
+          "rc-21-price-dec",
+          "rc-21-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-21-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-21-price-int",
+        "component": "Text",
+        "text": "2",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-21-price-dec",
+        "component": "Text",
+        "text": ".2",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-21-sales",
+        "component": "Text",
+        "text": "售300+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-21-tag0",
+        "component": "Text",
+        "text": "明天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-21-tag1",
+        "component": "Text",
+        "text": "回头率47%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-21-tag2",
+        "component": "Text",
+        "text": "7天无理由",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-21-footer",
+        "component": "Row",
+        "children": [
+          "rc-21-tag0",
+          "rc-21-tag1",
+          "rc-21-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-22",
+        "component": "Column",
+        "children": [
+          "rc-22-img",
+          "rc-22-body",
+          "rc-22-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-22-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01chapgl1Wjtz6WOiXz_!!2212019342825-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-22-body",
+        "component": "Column",
+        "children": [
+          "rc-22-title-row",
+          "rc-22-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-22-title-row",
+        "component": "Row",
+        "children": [
+          "rc-22-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-22-title",
+        "component": "Text",
+        "text": "纯净水桶养鱼创意透明鱼缸矿泉水桶改造生态鱼缸自制饮水机桶养鱼",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-22-price-row",
+        "component": "Row",
+        "children": [
+          "rc-22-price-sym",
+          "rc-22-price-int",
+          "rc-22-price-dec",
+          "rc-22-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-22-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-22-price-int",
+        "component": "Text",
+        "text": "31",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-22-price-dec",
+        "component": "Text",
+        "text": ".5",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-22-sales",
+        "component": "Text",
+        "text": "售100+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-22-tag0",
+        "component": "Text",
+        "text": "后天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-22-tag1",
+        "component": "Text",
+        "text": "回头率71%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-22-tag2",
+        "component": "Text",
+        "text": "7*24小时响应",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-22-footer",
+        "component": "Row",
+        "children": [
+          "rc-22-tag0",
+          "rc-22-tag1",
+          "rc-22-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-23",
+        "component": "Column",
+        "children": [
+          "rc-23-img",
+          "rc-23-body",
+          "rc-23-footer"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-23-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN014Z8UPd1LRcP0kHadl_!!2215524441296-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-23-body",
+        "component": "Column",
+        "children": [
+          "rc-23-title-row",
+          "rc-23-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-23-title-row",
+        "component": "Row",
+        "children": [
+          "rc-23-icon-0",
+          "rc-23-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-23-title",
+        "component": "Text",
+        "text": "娃娃屋1：12迷你监控摄像头模型仿真摄像头微缩食玩场景摆件模型",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-23-price-row",
+        "component": "Row",
+        "children": [
+          "rc-23-price-sym",
+          "rc-23-price-int",
+          "rc-23-price-dec",
+          "rc-23-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-23-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-23-price-int",
+        "component": "Text",
+        "text": "5",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-23-price-dec",
+        "component": "Text",
+        "text": ".85",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-23-sales",
+        "component": "Text",
+        "text": "售400+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-23-tag0",
+        "component": "Text",
+        "text": "后天达",
+        "styles": {
+          "font-size": "24px",
+          "color": "#22AC60",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-23-tag1",
+        "component": "Text",
+        "text": "回头率51%",
+        "styles": {
+          "font-size": "24px",
+          "color": "#BC8136",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-23-tag2",
+        "component": "Text",
+        "text": "7天无理由",
+        "styles": {
+          "font-size": "24px",
+          "color": "#999999",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "34px"
+        }
+      },
+      {
+        "id": "rc-23-footer",
+        "component": "Row",
+        "children": [
+          "rc-23-tag0",
+          "rc-23-tag1",
+          "rc-23-tag2"
+        ],
+        "align": "center",
+        "styles": {
+          "padding": "8px 12px",
+          "gap": "16px",
+          "background-color": "#FFFFFF"
+        }
+      },
+      {
+        "id": "rc-24",
+        "component": "Column",
+        "children": [
+          "rc-24-img",
+          "rc-24-body"
+        ],
+        "align": "stretch",
+        "styles": {
+          "width": "350px",
+          "border-radius": "16px",
+          "background-color": "#FFFFFF",
+          "overflow": "hidden",
+          "margin-bottom": "20px"
+        }
+      },
+      {
+        "id": "rc-24-img",
+        "component": "Image",
+        "url": "https://cbu01.alicdn.com/img/ibank/O1CN01KLDu8F1udXEkhJtvU_!!2220191956060-0-cib.jpg",
+        "styles": {
+          "width": "350px",
+          "height": "350px"
+        }
+      },
+      {
+        "id": "rc-24-body",
+        "component": "Column",
+        "children": [
+          "rc-24-title-row",
+          "rc-24-price-row"
+        ],
+        "align": "stretch",
+        "styles": {
+          "padding": "8px 16px",
+          "gap": "8px"
+        }
+      },
+      {
+        "id": "rc-24-title-row",
+        "component": "Row",
+        "children": [
+          "rc-24-title"
+        ],
+        "align": "center",
+        "styles": {
+          "gap": "8px",
+          "overflow": "hidden",
+          "height": "34px"
+        }
+      },
+      {
+        "id": "rc-24-title",
+        "component": "Text",
+        "text": "中古休闲折叠椅网红透明凳休闲拍照椅亚克力化妆凳咖啡店桌椅组合",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "normal",
+          "line-height": "32px",
+          "color": "rgba(0,0,0,0.87)",
+          "white-space": "nowrap",
+          "overflow": "hidden",
+          "text-overflow": "ellipsis"
+        }
+      },
+      {
+        "id": "rc-24-price-row",
+        "component": "Row",
+        "children": [
+          "rc-24-price-sym",
+          "rc-24-price-int",
+          "rc-24-sales"
+        ],
+        "align": "end",
+        "styles": {
+          "gap": "4px"
+        }
+      },
+      {
+        "id": "rc-24-price-sym",
+        "component": "Text",
+        "text": "¥",
+        "styles": {
+          "font-size": "28px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "28px"
+        }
+      },
+      {
+        "id": "rc-24-price-int",
+        "component": "Text",
+        "text": "85",
+        "styles": {
+          "font-size": "40px",
+          "font-weight": "bold",
+          "color": "#FF4000",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
+      },
+      {
+        "id": "rc-24-sales",
+        "component": "Text",
+        "text": "售500+件",
+        "styles": {
+          "font-size": "24px",
+          "color": "rgba(0,0,0,0.4)",
+          "margin-left": "8px",
+          "line-clamp": 0,
+          "white-space": "nowrap",
+          "line-height": "40px"
+        }
       }
     ]
   }


### PR DESCRIPTION
- Add dashed underline support on iOS, Android, and HarmonyOS
- Fix underline calculation for multi-line text
- Fix underline thickness unit conversion
- Fix strikethrough shorthand not working on iOS (#84206184)
- Fix image crop size not multiplied by screen density (#84253185)
- Optimize large image loading to reduce UI jank (#84077736)
- Fix horizontal List unable to dynamically append child elements
- Fix stability issues
- Remove unnecessary bottom margin in markdown rendering

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [ ] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [ ] Code compiles without errors on affected platform(s)
- [ ] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)