### PR TITLE
docs: add blog articles consumed by the website

### DIFF
--- a/docs/articles/README.md
+++ b/docs/articles/README.md
@@ -1,0 +1,92 @@
+# Blog Articles
+
+Source of truth for the blog articles rendered on the AGenUI website at `/logs`.
+
+The website fetches these files at runtime from `raw.githubusercontent.com`. It does
+not keep a local copy, so **this directory is the only place the articles live**.
+
+## Layout
+
+```
+docs/articles/
+├── index.json                 # manifest: the list + all article metadata
+├── <slug>.zh-CN.md            # article body
+└── README.md                  # this file
+```
+
+## Publishing an article
+
+Every article is **two** edits. Missing either one makes the article invisible.
+
+1. Add `docs/articles/<slug>.zh-CN.md`
+2. Add an entry to the `articles` array in `docs/articles/index.json`
+
+The website derives the markdown filename from `slug` (`<slug>.zh-CN.md`), so the two
+must agree exactly.
+
+## `index.json` schema
+
+```json
+{
+  "version": 1,
+  "articles": [
+    {
+      "slug": "my-article",
+      "title": "...",
+      "excerpt": "...",
+      "author": "AGenUI Team",
+      "date": "2026-07-27",
+      "category": "技术解读",
+      "tags": ["A2UI"]
+    }
+  ]
+}
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `slug` | yes | Must match `<slug>.zh-CN.md`. Also becomes the URL: `/logs/<slug>` |
+| `title` | yes | Rendered as the page `<h1>` |
+| `excerpt` | yes | Card summary on the list page, clamped to 2 lines |
+| `author` | yes | |
+| `date` | yes | Strictly `YYYY-MM-DD`. The list is sorted by this field, descending — the array order in this file is ignored. `2026-7-1` will sort incorrectly |
+| `category` | yes | Prefer one of `技术解读` / `实践分享` / `版本发布` / `社区动态`; other values are grouped at the end of the category filter |
+| `tags` | yes | Array of strings, may be empty |
+| `readTime` | no | Defaults to empty |
+| `featured` | no | Defaults to `false`; `true` shows a "featured" badge |
+
+## Markdown rules
+
+- **Keep the leading `# Heading`.** It makes the file readable on its own here on
+  GitHub. The website strips it before rendering, because the `<h1>` is already
+  rendered from `index.json`'s `title`.
+- **Do not add a language-switch line.** `docs/API.zh-CN.md` and
+  `docs/QuickStart.zh-CN.md` start with a `[English](...) | 中文` line because they
+  are bilingual; articles are not, and the website does not strip that line.
+- **All links and images must be absolute HTTPS URLs.** The website renders markdown
+  verbatim, so a relative path like `./images/x.png` resolves against the website
+  origin and 404s.
+- Articles are Chinese-only, hence the `.zh-CN.md` suffix (see
+  `agent-context/rules/english-only.md`). If an article is ever translated, add
+  `<slug>.md` alongside it — the website will need a change to pick it up.
+
+## Propagation
+
+The website reads the **public GitHub mirror**, not this GitLab repository. Pushing
+here is not enough; the change must reach `github.com/AGenUI/AGenUI` on `main`.
+
+`raw.githubusercontent.com` serves `cache-control: max-age=300`, so allow up to
+~5 minutes after the mirror updates before the change is visible.
+
+## Verifying
+
+```bash
+BASE=https://raw.githubusercontent.com/AGenUI/AGenUI/refs/heads/main/docs/articles
+for p in index.json my-article.zh-CN.md; do
+  echo "$(curl -s -o /dev/null -w '%{http_code}' "$BASE/$p")  $p"
+done
+```
+
+Both must return `200`. If `index.json` is unreachable the website shows a "failed to
+load" state with a retry button — it deliberately does not show an empty blog, so a
+broken mirror is visible rather than silent.

--- a/docs/articles/a2ui-elemental-format.zh-CN.md
+++ b/docs/articles/a2ui-elemental-format.zh-CN.md
@@ -1,0 +1,242 @@
+# 更"LLM友好"的 A2UI 生成格式：Elemental的功能特性
+
+## 前言
+
+[A2UI Elemental](https://github.com/a2ui-project/a2ui/tree/main/specification/proposals/elemental) 是 A2UI 官方在7月初引入的实验性特性。它采用类 HTML 的自定义标签协议来描述UI布局，目的是提高 A2UI 协议生成效率，降低协议生成门槛。从这一点来说它似乎和 Express DSL 的作用有些类似，但它们在数据载体格式上又有一些不同。A2UI Elemental 并非正式的协议规范，目前仍然是一个实验性质的提案。它的易用性、业务落地的真实效果等等还需要经过一定时间的检验。
+
+本文我们将解读一下 A2UI Elemental的核心特征、使用方式，以及对我们接入 A2UI 协议的参考和启示。
+
+### Elemental 介绍
+
+它是一种面向模型生成侧优化的声明式 UI 编码。从技术路线上看，它和 Express DSL 是相同的，即生成侧使用模型友好的、紧凑的协议，再使用编译器转换为标准的 A2UI JSON 协议供端侧渲染器消费。目标都是降低模型生成 A2UI 的成本、提高生成准确率。区别在于表达形态：一个是紧凑的 DSL，一个是类HTML的自定义标签协议。
+
+```plaintext
+<body id="dashboard-surface">
+  <ui-card id="root">
+    <ui-column id="main_column" align="stretch">
+    // ...
+    </ui-column>
+  </ui-card>
+</body>
+```
+
+### Elemental 的功能特性
+
+Elemental 出现的背景之一是：标准A2UI JSON协议对于模型生成可能不太友好。A2UI JSON 协议的扁平邻接表和父子节点id的前向引用使得大模型不得不关注唯一id的生成、长程的父子关系引用等。
+
+而 HTML 格式的嵌套层级、模型内化等特性天然就避免了上面的问题。以下是我们根据官方文档总结的Elemental的几个核心特性。
+
+1.  **模型友好**：HTML/XML格式是 LLM 在预训练阶段内化的“自然语言”，比生成自定义的A2UI JSON schema更加轻松顺手。出错率也更低
+    
+2.  **Token 效率**：HTML 标签、属性、自闭合标签常被识别为单个 token，比 JSON 格式表达的协议更加节省
+    
+3.  **天然树状层级**：HTML 本身是树状的嵌套结构，模型可以很自然地理解包含关系。不必理解长程的邻接表引用
+    
+4.  **自描述结构**：协议中直接注明属性名和取值，而非 Express DSL 中按照属性定义顺序确认属性值的方式
+    
+5.  **流式渲染**：HTML 格式协议可以流式解析和渲染
+    
+
+---
+
+## Elemental 的语法规则
+
+### 基本语法结构
+
+```html
+<a2ui>
+  <body id="dashboard-surface">
+    <link rel="catalog" href="https://a2ui.org/.../catalog.json" />
+    <!-- 组件/数据绑定写在这里 -->
+  </body>
+</a2ui>
+```
+
+*   最外层 `<a2ui>...</a2ui>` 是约定的标签，表示这个标签内部是UI描述协议。需要注意的是，标签`<a2ui>`在官方文档中没有提及，但是在编译器代码中进行了处理
+    
+*   `<body id>` 是对surface的定义。其中 `id` 就对应于 `surfaceId`；`<link rel="catalog">` 的 `href` 对应于引用的catalog
+    
+
+### 组件的定义规则
+
+组件标签一律增加`ui-` 前缀，后面接schema中定义的组件名称，组件名称的规则为kebab-case（小写并以连字符分隔多词）。比如：`<ui-card>`、`<ui-button>`、`<ui-icon>`、`<ui-text-input>`。每个组件定义时建议定义`id`属性，并指定为唯一的值。在编译器转换阶段，如果组件不包含`id`，则会默认生成一个唯一的`id`。
+
+组件的属性直接具名定义，可以不按照约定顺序定义属性，比如：
+
+```plaintext
+<ui-row id="header_row" justify="spaceBetween" align="center">
+```
+
+Elemental采用树状的嵌套层级定义节点包含关系，这是区别于A2UI JSON和Express DSL的最显著特征。
+
+```plaintext
+<ui-row id="header_row" justify="spaceBetween" align="center">
+  <ui-row id="header_left" align="center">
+    <ui-icon id="flight_indicator" name="send" />
+    <ui-text id="flight_number" text="{$/flightNumber}" />
+  </ui-row>
+</ui-row>
+```
+
+### 属性类型的定义规则
+
+根据属性值类型的不同，定义了不同的表示方式。
+
+| **A2UI 属性值** | **Elemental 写法** | **示例** |
+| --- | --- | --- |
+| 字符串 / 枚举 | 原始类型 | `align="stretch"`、`variant="body"` |
+| 数字 / 布尔 / null | 引号包花括号 `{...}` | `count="{4}"`、`checked="{true}"` |
+| 数据绑定 | `{$/...}` | `value="{$/user/name}"`、`{$name}` |
+| 函数 / 表达式 | `{fn(...)}` | `text="{formatCurrency(value: $/total, currency: 'USD')}"` |
+
+此外，Elemental定义了`<script>`标签用于表示一串原生的JSON协议，目前主要用于dataModel数据协议的下发。这部分下面会再介绍。比如：
+
+```plaintext
+<script type="application/json" slot="columns">[...]</script>
+```
+
+### updateDataModel事件的表示方法
+
+updateDataModel事件在Elemental格式中，被`<script>`标签包括，内部直接使用原始的JSON协议。比如原始 A2UI JSON 的 updateDataModel 协议内容为：
+
+```plaintext
+{
+  "version": "v1.0",
+  "updateDataModel": {
+    "surfaceId": "gallery-flight-status",
+    "value": {
+      "flightNumber": "OS 87",
+      "date": "2025-12-15",
+      "origin": "Vienna",
+      "destination": "New York"
+    }
+  }
+}
+```
+
+转换为 Elemental 格式后，表示方式为：
+
+```plaintext
+<body id="gallery-flight-status">
+  <script type="application/json">
+    {
+      "flightNumber": "OS 87",
+      "date": "2025-12-15",
+      "origin": "Vienna",
+      "destination": "New York"
+    }
+  </script>
+</body>
+```
+
+### 将Catalog 转换为"模型友好"型
+
+既然要让模型生成 类 HTML 格式的协议，那么也不能将json格式的catalog直接作为prompt的一部分输入给模型了。并且，将catalog压缩，也可以节省一定的输入token。
+
+Elemental 提案中，它把 catalog 的 JSON Schema 翻译成 TypeScript 格式作为输入prompt的部分内容。
+
+比如，下面是system prompt的一部分。
+
+```typescript
+## Workflow Description:
+# A2UI Elemental Output Contract
+
+You must output the user interface using A2UI Elemental HTML5-like markup.
+You MUST surround the entire block with the sentinel tags `<a2ui>` and `</a2ui>`.
+Inside the sentinel tags, surround the UI layout with `<body>` and `</body>` tags, including a `<link rel="catalog" href="https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json">` at the start.
+
+## HTML5 Markup Rules
+
+1. Prefix component tags with `ui-` in kebab-case (e.g., `<ui-text-field />`).
+2. Provide a unique `id` attribute for every component. The top-level root element must have `id="root"`.
+```
+
+而对于组件、属性描述等，则转换为TypeScript格式。
+
+```typescript
+type DataBinding = string;
+type A2UIElement = string; // ID of the referenced component
+type FunctionCall = string; // A catalog function call expression, e.g. "{formatString('Title: ${/path}')}" or "{regex(pattern: '^[A-Z]')}" 
+
+// Tag: <ui-audio-player>
+interface AudioPlayer {
+  id?: string;
+  // The URL of the audio to be played.
+  url: string | DataBinding;
+  // ...
+}
+```
+
+### Elemental 的生成与验证
+
+Elemental 在 A2UI 的 `agent_sdks` 中已经有完整的编译器、反编译器和 prompt 生成器实现，   但官方仓库没有提供像 Express DSL 那样便捷的命令行验证入口。为此我们补充了三个脚本，并已   [贡献给 A2UI 官方（PR #2099）](https://github.com/a2ui-project/a2ui/pull/2099)：
+
+*   `run_compiler.py`：将Elemental 标记转换为标准 A2UI v1.0 JSON
+    
+*   `run_decompiler.py`：将标准 A2UI JSON 转换为 Elemental 标记
+    
+*   `run_prompt_generator.py`：将basic catalog 转换为 Elemental 的 system prompt（含组件的 TSX 接口签名）
+    
+
+该PR中同样提交了作为`Elemental developer guide`的README文档。下载PR的脚本后，按照README中的描述，执行以下命令即可进行协议转换的验证。
+
+*   进入elemental目录
+    
+
+```plaintext
+cd specification/proposals/elemental
+```
+
+*   将01\_flight-status.json转换为Elemental格式并保存到flight.elemental文件中
+    
+
+```plaintext
+uv run --project ../../../agent_sdks/python/a2ui_agent \
+  scripts/run_decompiler.py
+  ../../v1_0/catalogs/basic/examples/01_flight-status.json 
+  > flight.elemental
+```
+
+*   将flight.elemental转换为标准A2UI JSON格式
+    
+
+```plaintext
+uv run --project ../../../agent_sdks/python/a2ui_agent \
+    scripts/run_compiler.py flight.elemental
+```
+
+*   将basic catalog转换为输入给LLM的prompt
+    
+
+```plaintext
+uv run --project ../../../agent_sdks/python/a2ui_agent \
+  scripts/run_prompt_generator.py --catalog
+  ../../v1_0/catalogs/basic/catalog.json
+```
+
+---
+
+## Elemental的收益提升
+
+基于A2UI 官方发布的[评测数据](https://github.com/a2ui-project/a2ui/blob/main/eval/baselines/elemental/run_meta.json)，我们可以看到相对于A2UI JSON格式，Elemental有哪些方面的提升。
+
+| **格式** | **语法/结构准确率** | **语义准确度** | **输出 token中位数** | **输入token中位数** |
+| --- | --- | --- | --- | --- |
+| A2UI JSON | 0.980 | 0.902 | 975 | 10485 |
+| Elemental | 0.980 | 0.941 | 539 | 5671 |
+
+相比较于A2UI JSON，Elemental 输出 token 降低约 45%，输入 token 降低约 46%。在保证语法准确度不降低的情况下，语义准确度也提升。可以说是一个“全面的”提升。从评测结果来看，可能也印证了之前的一个判断：大模型输出类 HTML 格式更自然更准确。
+
+---
+
+## 总结
+
+作为 A2UI 应用领域又一个“节能提效”的提案，从评测数据上看 Elemental 在各方面都有一定程度的提升。但是在决策是否在真实业务场景中使用时，我们必须摸清楚它的所有特性和约束。
+
+首先，Elemental 面向的是协议生成侧，即大模型以及与模型交互的server agent。协议消费侧，即渲染器可能接收的还是标准A2UI JSON。所以，server agent可能需要完成协议的编译和转换，这是一个额外的工作量新增。
+
+其次，一面是标准的A2UI JSON，另一面是Elemental。虽然它们有相同的组件schema、属性定义、事件定义等，但是在表达方式有较大的差异（**JSON vs HTML，邻接表 vs 嵌套层级**）。开发者不得不同时掌握这两类协议才能更好地将Elemental应用在真实业务场景。
+
+最后，Elemental 现在依然是提案阶段，可能面临调整，而且在协议演进、规则检查等方面还需要更加完善的建设。但是，作为在"生成式 UI 成本优化"这个方向上的又一次务实探索，值得进行研究和验证。
+
+> 如果你对生成式 UI 感兴趣，欢迎关注我们的开源项目 [AGenUI](https://github.com/AGenUI/AGenUI)——**支持 iOS、Android 和 HarmonyOS 的高性能 A2UI 渲染引擎**。它基于共享 C++ 核心引擎 + 三端原生渲染架构，完整实现了 A2UI v0.9 协议，能够在移动设备上实时流式渲染 LLM 生成的可交互 UI。欢迎 Star、试用、提 Issue，一起推动生成式 UI 在移动端的落地。

--- a/docs/articles/a2ui-express-dsl.zh-CN.md
+++ b/docs/articles/a2ui-express-dsl.zh-CN.md
@@ -1,0 +1,299 @@
+# 更低成本地生成A2UI协议：Express DSL的功能特性
+
+### 前言
+
+在将A2UI应用到生产环境中时，会遇到一个绕不开的问题：如何让LLM高效、低成本、稳定地生成高质量的协议。这个问题中的几个评估要素包括生成耗时、token消耗、语法准确率（静态规则）、语义准确率（满足意图）等。这个问题直接影响了A2UI协议在真实业务落地中的成本和效果。
+
+在2026年6月份，A2UI官方引入了一个实验性的特性，[Express DSL](https://github.com/a2ui-project/a2ui/tree/main/specification/proposals/express)。似乎为上面的问题提供了一个解题路径，但是解决问题的效果怎么样还不得而知。下面我们就来探索一下Express DSL的规则、使用方法和优化效果。
+
+#### Express DSL的定位
+
+它这不是一个新协议，而是一种LLM生成的、高度压缩的的DSL。即模型生成紧凑的 Express DSL，再由一个编译器把它编译回标准的 A2UI v1.0 JSON。官方文档对它的一句话定义是：
+
+> "A2UI Express is a compact, model-optimized declarative syntax... It acts as an intermediate, highly compressed representation that on-device large language models generate to describe user interfaces. A host-side compiler parses this syntax and compiles it into standard A2UI v1.0 wire protocol payloads." —— `specification/proposals/express/a2ui_express.md`
+
+#### Express DSL的当前进展
+
+我们需要特别说明Express DSL的当前状态。
+
+*   核心介绍文档在 `specification/proposals/` 目录下，而不是已认证的 `specification/v1_0/` 目录。也就是说，它是一个**提案（proposal）**，而非正式规范。
+    
+*   在官方提供的python版本agent sdk中。必须设置环境变量 `A2UI_EXPRESS_ENABLED` 为true，才能启用Express功能。
+    
+*   官方在合入时刻意做了收敛。比如不影响原有agent的主链路；把实现放进 `a2ui.experimental.express` 命名空间中等。
+    
+
+虽然这个功能并非A2UI的正式规范，依然在演进和验证阶段，但是作为真实业务落地问题的一个探索型解法，还是值得研究的。
+
+---
+
+### Express DSL的设计目标和原则
+
+官方在技术规范里明确列出了 A2UI Express 的四个核心设计目标，这也正是它的设计意图所在。
+
+*   **减少token消耗。** 生成式模型在产出冗长 JSON 时会消耗大量输出 token。Express DSL去掉了结构键、括号和重复引号，官方测试结果显示，相比原生 A2UI协议，输出 token消耗明显降低。
+    
+
+原始A2UI协议：
+
+```plaintext
+{
+  "id": "root",
+  "component": "Card",
+  "child": "main_column"
+},
+{
+  "id": "main_column",
+  "component": "Column",
+  "children": [
+    "header_row",
+    "route_row"
+  ],
+  "align": "stretch"
+}
+```
+
+Express DSL：
+
+```plaintext
+root = Card(main_column)
+main_column = Column([header_row, route_row], "stretch")
+```
+
+*   **端侧小模型优化。** Express DSL支持在端侧小模型生成，比如官方提到的模型Gemma 4 E2B / E4B等。这类模型的上下文窗口有限、推理预算紧张。得益于Express DSL清晰的规则，较少的协议闭合规则等，让模型能在较小的推理空间内完成生成。
+    
+*   **兼容流式输出。** Express DSL 采用行式（line-oriented）语法，即每个组件定义在单独的一行，使得编译器可以逐行解析、逐步构建组件树，在模型还没输出完时就能渐进式渲染。
+    
+*   **协议对齐。** Express DSL与标准 A2UI v1.0 保持对齐，比如完整支持数据绑定、客户端校验规则、本地事件处理等。
+    
+
+从这四点来看。A2UI官方在希望保持A2UI协议完整性、标准化能力的基础上，用一个中间 DSL，把"生成UI"这件事变得更便宜、更快、更适合在端侧的小模型上运行。
+
+---
+
+### 协议规则与使用方式
+
+#### 基本语法
+
+Express DSL的所有 UI 布局都包裹在 `<a2ui>` 和 `</a2ui>` 标签里，用来和普通对话文本区分开。在标签内部的正文部分，每一行都代表了一个组件或数据绑定定义：
+
+```plaintext
+<a2ui>
+$数据绑定key = 数据绑定value
+变量名 = 组件名(参数1, 参数2, ...)
+</a2ui>
+```
+
+**核心规则**：
+
+*   必须存在`root` 变量，代表整个协议代表的页面树的根节点。这与标准A2UI协议要求一致。
+    
+*   **禁止内联嵌套**：组件构造只能出现在赋值语句右侧，不能作为参数直接塞进另一个组件。要引用子组件，必须先给它单独声明一个变量，再用变量名引用。这条规则是为了消除复杂括号带来的语法错误，并支持逐行流式编译。
+    
+*   **变量名遵循 Unicode 标识符规范**：字母或下划线开头，后接字母、数字、下划线。
+    
+
+#### 协议示例
+
+下面是官方示例中[飞机行程卡片](https://github.com/a2ui-project/a2ui/blob/main/specification/proposals/express/examples/01_flight-status.a2ui)（FlightStatus）的Express DSL代码：
+
+```plaintext
+<a2ui>
+$/arrivalTime = "2025-12-15T14:30:00Z"
+$/date = "2025-12-15"
+$/departureTime = "2025-12-15T10:15:00Z"
+$/destination = "New York"
+$/flightNumber = "OS 87"
+$/origin = "Vienna"
+$/status = "On Time"
+root = Card(main_column)
+main_column = Column([header_row, route_row, divider, times_row], _, "stretch")
+header_row = Row([header_left, date], "spaceBetween", "center")
+header_left = Row([flight_indicator, flight_number], _, "center")
+flight_indicator = Icon("send")
+flight_number = Text($/flightNumber)
+date = Text(formatDate($/date, "E, MMM d"), "caption")
+route_row = Row([origin, arrow, destination], _, "center")
+origin = Text(formatString("## ${/origin}"))
+arrow = Text("## →")
+destination = Text(formatString("## ${/destination}"))
+... ...
+</a2ui>
+```
+
+参考：飞机行程卡[原始A2UI协议](https://github.com/a2ui-project/a2ui/blob/main/specification/v1_0/catalogs/basic/examples/01_flight-status.json)。
+
+需要注意的是，在官方提供的脚本和agent\_sdk中的逻辑中，当编译器把上述协议还原成标准 A2UI v1.0 协议时，是一个 `createSurface` 事件内部包括`components`和`dataModel`字段（v1.0新支持的特性），而非单独的`createSurface`、`updateComponents`和`updateDataModel`事件。
+
+#### 规则速查表
+
+| **维度** | **写法** | **说明** |
+| --- | --- | --- |
+| 组件定义 | `varname = ComponentName(arg1 ...)` |  |
+| 字符串 | `"文本"` / `"""多行"""` / `r"正则\d+"` | 支持转义串与原始串（raw string），正则很方便 |
+| 数字 / 布尔 / 空 | `42` / `true` / `null` |  |
+| 列表 | `[child1, child2]` | 映射到容器的子槽位 |
+| 数据绑定 | `$/user/email`/ `$lastName` | `$` 前缀绑定到数据模型 |
+| 数据填充 | `$/title = "启用通知"` | 直接给数据路径赋值，写进 `dataModel` |
+| 动态列表模板 | `List(_template($/breeds, tpl), "horizontal")` | `_template` 辅助函数生成模板子列表 |
+| 服务端事件 | `Event("save_deal", {rep: $/form/rep})` |  |
+| 客户端函数 | `openUrl("https://...")` | 直接按 catalog 签名调用 |
+| 删除surface | `deleteSurface("surface-1")` | 独立语句，无需赋值 |
+
+#### 省 token 的核心机制
+
+Express DSL省 token 的核心在于它省略了所有属性名（key），完全靠"参数位置"来映射。并且省略了所有json格式中的换行、括号等。
+
+上段话中提到：属性要靠"参数位置"来映射。下面我们来解析下它的含义。
+
+按照Express DSL的规则，组件属性的解析顺序完全由在 catalog 定义的顺序决定。Express 不硬编码任何组件名或属性，换 catalog、扩展组件都不用改编译器代码。
+
+比如以下A2UI协议：
+
+```plaintext
+{
+  "id": "tc_root",
+  "component": "Row",
+  "children": [
+    "tc_card"
+  ],
+  "align": "stretch",
+  "justify": "spaceBetween"
+}
+```
+
+转换后的Express DSL协议为：
+
+```plaintext
+tc_root = Row([tc_card], "spaceBetween", "stretch")
+```
+
+很明显，从以上协议转换规则来看，`justify`在`align`之前。那么，如果没有注明`justify`属性呢？Express DSL也定义了规则应对这种情况：
+
+*   中间要跳过的可选参数用下划线 `_` 占位。
+    
+
+*   尾部的可选参数可以直接省略。
+    
+
+如果`justify`没有指定，那么转换后的Express DSL就是：
+
+```plaintext
+tc_root = Row([tc_card], _, "stretch")
+```
+
+需要注意的是，以上规则带来一个潜在的问题问题：如果对A2UI进行扩展，引入了新的属性。那么接入Express DSL时必须做相应的适配，否则新扩展的属性无法被正确解析。
+
+#### 输入 catalog 的压缩方法
+
+既然要让模型生成 Express DSL，那喂给模型的 catalog 也不能再是原始 JSON Schema 了。并且将catalog压缩，也是节省输入token的一个手段。
+
+官方提供了 `ExpressPromptGenerator`，把 catalog 编译成紧凑的格式塞进LLM的prompt中。验证命令为：
+
+```plaintext
+// 进入目录specification/proposals/express
+A2UI_EXPRESS_ENABLED=true uv run --project ../../../agent_sdks/python/a2ui_agent scripts/run_prompt_generator.py --catalog ../../v1_0/catalogs/basic/catalog.json
+```
+
+命令执行成功后，会生成一段prompt，其中就包含了对组件、属性、函数等的说明。
+
+```plaintext
+• Button(child (component ID), variant? (static only), action (static only), weight? (static only))
+  - child: The ID of the child component...
+  - variant: ... Must be one of: 'default', 'primary', 'borderless'
+```
+
+#### 何时转换到标准 A2UI 协议
+
+对于Express DSL，不免有一个疑问：是在server agent侧还是客户端侧将Express DSL转换为A2UI协议呢？
+
+当前官方设计是：
+
+*   模型直接输出 Express DSL 
+    
+*   server agent 侧编译器转换为标准 v1.0 协议
+    
+*   将 A2UI 协议下发到客户端进行渲染
+    
+
+这种处理方式的优势是显而易见的：
+
+1.  职责分离。server agent + LLM负责生成完整的A2UI协议，内部可以实现规则检测、循环验证等手段保证协议准确性
+    
+2.  保证客户端渲染器能力纯粹性，只面向A2UI协议，不引入其他协议规则
+    
+
+---
+
+### Express DSL的收益
+
+基于A2UI在官方在提交提案时展示的数据，Express DSL在节省token方面还是有比较大的提升的。
+
+使用轻量模型 `gemini-3.1-flash-lite`、47 个样本，对比"标准A2UI"与"Express DSL"两种策略：
+
+| **策略** | **语法准确率** | **语义准确率** | **平均延迟** | **输出 token** | **总 token** |
+| --- | --- | --- | --- | --- | --- |
+| 标准A2UI | 87.23% | 93.62% | 4.99s | 35,022 | 527,882 |
+| Express DSL | 91.49% | 84.04% | 1.09s（↓78%） | 9,912（↓72%） | 232,748（↓56%） |
+
+首先，协议生成延迟和token消耗大幅降低，这个方面达成了Express DSL设计的目的。同时，语法准确率（即生成协议的静态规则准确性）还有一定的提升，这个属于意外的惊喜。
+
+但是，语义准确率反而降低了。语义准确率是通过另外一个更高级的LLM对生成的协议和输入的需求进行评分，评估结果满足需求意图的程度。从结果来看，引入简化、清晰规则的Express DSL后，反映静态规则的语法更准确了，反映模糊意图的语义更模糊了。
+
+我们团队实地验证过Express DSL的优化效果，和A2UI官方提供的结论基本一致。我们必须充分了解Express DSL特点的两面性，这能帮助我们更好地决策它适合什么业务场景。
+
+---
+
+### Express DSL优缺点汇总
+
+#### Express DSL的优点
+
+*   **节省token、低延迟**
+    
+*   **端侧友好**。支持端侧小模型 ，适合离线、隐私、边缘场景。
+    
+*   **降低了模型门槛**：使用编译器进行规则检测和转化，语法准确率提升，降低对强模型的依赖度
+    
+*   **流式渐进渲染**：每个组件单独一行的定义方式天然支持流式渲染
+    
+*   **端侧渲染器零侵入**：将Express DSL的生成和转换封装在服务端，保持端侧渲染层纯净
+    
+
+#### Express DSL的缺点和风险
+
+*   **语义准确率下降**。可能无法适合复杂样式的生成。
+    
+*   **转换规则复杂度** 。当前官方提供的示例中，不产出独立 `updateComponents`事件，不太符合固有使用习惯
+    
+*   **协议理解成本**。开发者在理解A2UI协议后，不得不掌握Express DSL规则，提高了成本
+    
+*   **适配成本**。新增事件、属性、修改规则后可能要适配编译器
+    
+*   **仍是实验特性**：Express DSL属于 `proposal`，非正式协议，有可能变动
+    
+
+#### 推荐考虑接入的场景
+
+*   调用量大，对token 成本敏感；或倾向使用端侧 / 离线小模型
+    
+*   生成的样式较为简单，接受一定程度的语义差异
+    
+*   能够接受在服务端加一道"编译 + 校验 + 重试"的能力，以适配弱模型
+    
+
+#### 不推荐接入的场景
+
+*   主要使用前沿大模型，对token消耗没有过多限制
+    
+*   需要生成复杂样式，对语法准确性、语义准确性有同等的要求
+    
+*   对协议进行了扩展，且持续演进。不希望引入额外的Express DSL维护成本
+    
+*   需要稳定性 / 标准化保证（Express DSL仍是提案和实验特性）。
+    
+
+### 总结
+
+Express DSL 是A2UI官方在"生成式 UI 的成本优化，业务落地友好型"这个方向上的一次务实探索。它不在于解决"让模型生成的更对更好看"的问题，而在于"让模型生成的成本更低"。虽然它还处在实验阶段，但是值得保持关注和小范围试点验证。
+
+> 如果你对生成式 UI 感兴趣，欢迎关注我们的开源项目 [AGenUI](https://github.com/AGenUI/AGenUI)——**支持 iOS、Android 和 HarmonyOS 的高性能 A2UI 渲染引擎**。它基于共享 C++ 核心引擎 + 三端原生渲染架构，完整实现了 A2UI v0.9 协议，能够在移动设备上实时流式渲染 LLM 生成的可交互 UI。欢迎 Star、试用、提 Issue，一起推动生成式 UI 在移动端的落地。

--- a/docs/articles/a2ui-over-mcp.zh-CN.md
+++ b/docs/articles/a2ui-over-mcp.zh-CN.md
@@ -1,0 +1,196 @@
+# 当 A2UI 遇上 MCP：生成式 UI 的一种新模式？
+
+> 最近，A2UI 团队最近发起了一个 [Discussion](https://github.com/a2ui-project/a2ui/discussions/1676)，讨论 A2UI 结合 MCP 进行协议扩展的可行性。在声明式协议和开放式协议共同发展的今天，这个观点确实有点意思。作为 A2UI 协议的深度参与者，我们对此进行了调研和思考，在这里和大家分享。
+
+### 先说结论
+
+A2UI over MCP 的核心是：**A2UI 协议不仅可由 LLM 实时生成，MCP Server 也可以直接构造和下发 A2UI 协议**。这不是两个协议的简单拼接，而是对"A2UI 协议真实赋能业务解题"的一次重新思考。
+
+---
+
+### A2UI vs MCP：两个协议的特点
+
+在聊 A2UI over MCP 之前，我们先快速回顾一下这两个协议各自的定位。
+
+#### A2UI：安全、跨平台的声明式 UI 协议
+
+[A2UI](https://github.com/google/A2UI) 是 Google 开源的一套声明式 UI 协议。它的设计哲学是：**LLM 负责定义"界面长什么样"的结构化描述，客户端渲染器负责把这些描述画出来**。
+
+这种架构天然带来几个好处：
+
+*   **安全**：客户端不执行任何来自服务端的代码，只解析声明式的 JSON 数据
+    
+*   **跨平台**：同一份 A2UI 协议，可以在 Web、iOS、Android、HarmonyOS 上由各自的渲染器绘制
+    
+*   **流式渲染**：支持增量更新，LLM 一边生成一边渲染，体验流畅
+    
+
+但它也有一个明显的限制：**A2UI 协议本身不支持执行复杂的客户端逻辑**。它是声明式协议，能描述"一个按钮点击后触发某个 action"，但做不到"点击后执行一段计算逻辑再更新 UI"。对于需要复杂交互的业务场景，这是一个实实在在的瓶颈。
+
+#### MCP：灵活、强大的工具协议
+
+[MCP](https://modelcontextprotocol.io/)（Model Context Protocol）是 Anthropic 提出的一套开放协议，本质上是给 AI 模型提供了一种标准化的方式来调用外部工具和访问资源。在此基础上，MCP 进一步推出了 [MCP Apps](https://modelcontextprotocol.io/specification/2025-12-17/server/apps)——通过 iframe 沙盒承载完整的 HTML 应用，支持复杂的交互逻辑。
+
+MCP（及 MCP Apps）的表达力非常强：你可以在里面跑 JavaScript，做状态管理，实现任意复杂的 UI 交互。但它面临一些问题：
+
+*   **安全性**：需要 iframe 沙盒隔离
+    
+*   **性能开销**：HTML/JS 在沙盒中运行，相比原生渲染有性能损耗
+    
+*   **体验割裂**：嵌入的 Web 页面和原生 UI 之间可能存在视觉和交互上的不一致
+    
+
+简单来说：**A2UI 安全但逻辑受限，MCP 灵活但存在安全和体验代价**。在特点上两者似乎有一种天然的互补关系。
+
+---
+
+### A2UI over MCP：不只是"拼在一起"
+
+理解了各自的优劣，再来看 A2UI over MCP 就很自然了。
+
+Google A2UI 团队的意图很明确：**在 A2UI 的安全性与 MCP 的表达力之间找到融合点，给开发者提供更多生成式 UI 落地时的技术选型空间**。
+
+这里有一个关键的思路转变：传统的 A2UI 落地方式是LLM 生成协议，然后客户端渲染，而 A2UI over MCP 拓宽了这个范式——**MCP Server 可以直接构造 A2UI 协议数据，不需要经过 LLM 的推理和生成**。A2UI 协议从"LLM 输出的声明式UI协议"变成了"一种通用的 UI 描述语言"。
+
+这意味一个 MCP Server 可以像构建 API 响应一样构建 A2UI 协议，客户端渲染器照常解析和绘制。整个过程不需要 LLM 参与，但 UI 依然享有 A2UI 协议的安全性和跨平台能力。
+
+---
+
+### A2UI over MCP的三种集成模式
+
+A2UI over MCP 并不是一种固定的技术方案，而是提供了三种不同的集成模式。每种模式在安全性、表达力和架构复杂度上各有侧重。
+
+#### 模式一：MCP Server 直接下发 A2UI 协议
+
+**一句话概括：MCP Server 构建 A2UI JSON，客户端渲染器画出来。**
+
+这是最直接的集成方式。在 MCP 的 Resource 或 Tool Call 链路中，把 A2UI 协议 JSON 作为响应内容下发。客户端侧只需要接入 A2UI 渲染器即可。
+
+这种模式又分为两种子模式：
+
+**Static 模式**：MCP Server 直接返回预设的 A2UI JSON，没有任何逻辑运算。适合展示固定内容的场景。
+
+```python
+@app.read_resource()
+async def read_resource(uri: str) -> list[ReadResourceContents]:
+    if str(uri) == "a2ui://recipe-form":
+        return [ReadResourceContents(
+            content=json.dumps(recipe_form_json),  # 预设的 A2UI JSON
+            mime_type="application/a2ui+json",
+        )]
+```
+
+**Tool Call 模式**：客户端携带参数请求，MCP Server 根据参数执行逻辑后组装 A2UI 协议数据返回。可以基于预设模板进行数据填充。
+
+```python
+@app.call_tool()
+async def handle_call_tool(name: str, arguments: dict) -> CallToolResult:
+    if name == "get_recipe_a2ui":
+        custom_recipe_json = copy.deepcopy(recipe_a2ui_json)  # 基于模板
+        for action in custom_recipe_json:
+            if "updateDataModel" in action:
+                action["updateDataModel"]["value"] = {
+                    "title": recipe_data["title"],    # 注入动态数据
+                    "rating": recipe_data["rating"],
+                }
+        return CallToolResult(content=[EmbeddedResource(
+            resource=TextResourceContents(
+                uri="a2ui://recipe-card",
+                mimeType="application/a2ui+json",
+                text=json.dumps(custom_recipe_json),
+            )
+        )])
+```
+
+这种模式的优势在于简单、安全，MCP Server 只负责数据和协议构造，渲染完全在客户端完成。同一套 MCP Server 产出的 A2UI 数据可以在不同平台的渲染器上呈现。
+
+![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/Q35O851yW8VJWl9V/img/7ceee61a-21ac-4b4c-955d-9236ee78db80.png)
+
+#### 模式二：A2UI 中嵌入 MCP Apps
+
+**一句话概括：A2UI 是容器，MCP Apps 是嵌入的内容。**
+
+在已接入 A2UI 渲染器的页面中，注册一个自定义的 `McpApp` 组件，用 iframe 沙盒承载 MCP Apps 的 HTML 页面。A2UI 协议中通过 `content` 字段下发 MCP Apps 的内容：
+
+```json
+{
+  "component": {
+    "McpApp": {
+      "content": {"literalString": "url_encoded:%3C!doctype%20html%3E..."},
+      "title": {"literalString": "Calculator"},
+      "allowedTools": ["calculate"]
+    }
+  }
+}
+```
+
+在这种模式下，A2UI 渲染器充当 MCP Apps 与后端 Server 之间的交互桥梁。MCP Apps 内部的工具调用需要封装为 A2UI Action，经由渲染器转发。
+
+![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/Q35O851yW8VJWl9V/img/22d8bd06-5830-4f53-9ca7-bf3752daa5fa.png)
+
+这种模式的核心价值是：**让接入了 A2UI 的页面获得更强的表现力和复杂交互能力**。A2UI 原生组件负责主体 UI，遇到需要复杂逻辑的局部区域，交给嵌入的 MCP Apps 处理。
+
+#### 模式三：MCP Apps 中嵌入 A2UI
+
+**一句话概括：MCP Apps 是容器，A2UI 是嵌入的内容。**
+
+这个模式的方向和模式二恰好相反。客户端页面首先是一个 MCP Apps 容器（iframe），内部挂载 A2UI 渲染器（必须是web渲染器）。A2UI 协议数据通过 MCP 的 Resource 或 Tool Call 获取，然后在 MCP Apps 内部渲染。
+
+![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/Q35O851yW8VJWl9V/img/2c15f19f-a2d5-4659-94bc-362e8f26d168.png)
+
+这种模式最大的优势是赋予了MCP Apps页面的**能力局部刷新**：A2UI 协议天然支持增量更新，页面变更时只需下发需要更新的组件或数据，而不需要重新下发整个 MCP Apps 页面。
+
+此外，它还有一个有意思的应用场景：**对于那些不原生支持 A2UI 的宿主环境，可以通过 MCP Apps 的 iframe 来引入 A2UI 的渲染能力**。老系统只需要支持基本的 MCP Apps iframe 容器，就能获得动态 AI 交互能力。
+
+#### 三种模式的对比
+
+| **维度** | **模式一：MCP 下发 A2UI** | **模式二：A2UI 嵌 MCP Apps** | **模式三：MCP Apps 嵌 A2UI** |
+| --- | --- | --- | --- |
+| 架构关系 | MCP 是通道，A2UI 是内容 | A2UI 是容器，MCP Apps 是内容 | MCP Apps 是容器，A2UI 是内容 |
+| 安全性 | 高（纯声明式） | 需 iframe 沙盒 | 需 iframe 沙盒 |
+| 表达力 | A2UI 标准组件 | A2UI + 任意 HTML/JS | 任意 HTML/JS + A2UI 局部渲染 |
+| 原生渲染支持 | 支持 | 部分（MCP Apps 区域为 Web） | 仅 Web |
+
+---
+
+### 我们的思考
+
+整体上，我们认为 A2UI over MCP 在生成式UI业务落地中引出一些新的思路，以下亮点是我们值得关注的。
+
+#### "预生产模板"不是妥协，可能是一种标准的落地方式
+
+在将 AGenUI 应用到实际业务场景的过程中，我们也探索了"预生产协议模板"的模式：服务端根据客户端请求下发预设的 A2UI 协议模板，或者执行业务逻辑后对模板进行数据组装，全程不需要 LLM 参与协议的实时生成。
+
+这和 A2UI over MCP 的模式是一样的思路。这种看起"折中"的方案，在未来是否会成为 **A2UI 协议落地的一种标准方式**，值得我们关注。这个思路也更凸显出另外一点：A2UI 协议的价值不仅在于"让 LLM 生成 UI"，更在于它作为一种跨平台、安全、声明式的 UI 描述语言的通用性。
+
+#### "Logic in A2UI"：一个值得探索的方向
+
+模式二（MCP Apps in A2UI）给我们的启发是：**A2UI 渲染器如何在保持安全性的前提下，支持更复杂的业务逻辑？**
+
+MCP Apps in A2UI 提供了一个解题思路：把复杂逻辑交给 iframe 中的 MCP Apps 处理。但对于原生渲染器来说，引入 iframe 和 Web 技术栈意味着额外的复杂度和性能开销。这种解决问题A引入问题B的模式在真正业务落地时要做好权衡。
+
+但是，顺着这个思路我们更进一步思考。本质问题是："A2UI 能不能支持某种形式的逻辑执行？"，我们暂且称之为 "Logic in A2UI"。可能是下发可执行的表达式、轻量脚本，或者某种受限的 DSL。当然，这和 A2UI 协议的安全性设计需要调和，需要谨慎探索。但我们认为这是一个值得关注的方向。
+
+---
+
+### 写在最后
+
+A2UI over MCP 目前仍处于早期阶段，Google 已经在 Discussion 中征集社区意见，具体的 MCP Extension 规范尚未确定，但是我们能够看出 A2UI 协议在易用性、业务友好性方向上的持续探索。我们会持续关注进展，也期待和社区一起参与。
+
+> 如果你对生成式 UI 感兴趣，欢迎关注我们的开源项目 [AGenUI](https://github.com/AGenUI/AGenUI)**——支持 iOS、Android 和 HarmonyOS 的高性能 A2UI 渲染引擎。它基于共享 C++ 核心引擎 + 三端原生渲染架构，完整实现了 A2UI v0.9 协议，能够在移动设备上实时流式渲染 LLM 生成的可交互 UI。欢迎 Star、试用、提 Issue，一起推动生成式 UI 在移动端的落地。**
+
+---
+
+**参考资料**
+
+*   [A2UI over MCP - A2UI 官方指南](https://a2ui.org/guides/a2ui_over_mcp/)
+    
+*   [MCP Apps in A2UI - A2UI 官方指南](https://a2ui.org/guides/mcp-apps-in-a2ui/)
+    
+*   [A2UI in MCP Apps - A2UI 官方指南](https://a2ui.org/guides/a2ui-in-mcp-apps/)
+    
+*   [A2UI + MCP Apps: Combining the best of declarative and custom agentic UIs - Google Developers Blog](https://developers.googleblog.com/a2ui-and-mcp-apps/)
+    
+*   [A2UI as MCP Extension - GitHub Discussion](https://github.com/a2ui-project/a2ui/discussions/1676)
+    
+*   [AGenUI - GitHub](https://github.com/AGenUI/AGenUI)

--- a/docs/articles/index.json
+++ b/docs/articles/index.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "articles": [
+    {
+      "slug": "a2ui-elemental-format",
+      "title": "更「LLM 友好」的 A2UI 生成格式:Elemental 的功能特性",
+      "excerpt": "A2UI Elemental 是官方 7 月初引入的实验性特性,采用类 HTML 的自定义标签协议描述 UI 布局,以降低协议生成门槛。本文解读其核心特征、使用方式与启示。",
+      "author": "AGenUI Team",
+      "date": "2026-07-27",
+      "category": "技术解读",
+      "tags": ["A2UI", "Elemental", "生成格式"]
+    },
+    {
+      "slug": "a2ui-express-dsl",
+      "title": "更低成本地生成 A2UI 协议:Express DSL 的功能特性",
+      "excerpt": "如何让 LLM 高效、低成本、稳定地生成高质量 A2UI 协议?本文探索官方实验特性 Express DSL 的规则、使用方法与优化效果。",
+      "author": "AGenUI Team",
+      "date": "2026-07-13",
+      "category": "技术解读",
+      "tags": ["A2UI", "Express DSL", "协议生成"]
+    },
+    {
+      "slug": "a2ui-over-mcp",
+      "title": "当 A2UI 遇上 MCP:生成式 UI 的一种新模式?",
+      "excerpt": "A2UI 团队发起 Discussion 讨论 A2UI 结合 MCP 进行协议扩展的可行性。作为 A2UI 协议的深度参与者,我们对 A2UI over MCP 这一新模式进行了调研与思考。",
+      "author": "AGenUI Team",
+      "date": "2026-06-30",
+      "category": "技术解读",
+      "tags": ["A2UI", "MCP", "协议扩展"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `docs/articles/` — the blog articles rendered on the AGenUI website — so the
content lives next to the code it describes instead of being maintained separately
in the website repository.

The website already fetches `docs/QuickStart.md` and `docs/API.md` from this repo at
runtime. This change lets it do the same for the blog, which removes the duplicate
source of truth and decouples article updates from the website release flow.

- `index.json` is the manifest: it drives article discovery and carries all metadata
  (title, excerpt, author, date, category, tags). The list page therefore needs a
  single ~1.5 KB request instead of downloading every article to read frontmatter.
- Each article keeps its leading `# Heading` so the file reads on its own here on
  GitHub; the website strips it before rendering, since it renders the `<h1>` from
  `index.json`.
- `README.md` documents the authoring contract: two-file publishing (markdown +
  manifest entry), absolute HTTPS URLs only, no language-switch line, and the
  ~5 minute `raw.githubusercontent.com` cache window.

Articles are Chinese-only, hence the `.zh-CN.md` suffix, consistent with the existing
`docs/QuickStart.zh-CN.md` / `docs/API.zh-CN.md` naming.

## Contents

| File | Notes |
| --- | --- |
| `docs/articles/index.json` | Manifest, 3 entries |
| `docs/articles/a2ui-elemental-format.zh-CN.md` | 2026-07-27 |
| `docs/articles/a2ui-express-dsl.zh-CN.md` | 2026-07-13 |
| `docs/articles/a2ui-over-mcp.zh-CN.md` | 2026-06-30 |
| `docs/articles/README.md` | Authoring contract |

Documentation only — no source, build, or CI changes.

## Test plan

- [x] `index.json` parses; every `slug` has a matching `<slug>.zh-CN.md` and vice versa
- [x] Article bodies are byte-identical to the previously published versions (only the
      YAML frontmatter block was removed)
- [x] Every article starts with a single `# Heading`
- [x] All links and images in the articles are absolute HTTPS URLs (verified reachable)
- [x] Rendered end to end against a local build of the website: list ordering, category
      and tag filters, detail pages, and image loading all behave as before
- [ ] After merge: confirm `https://raw.githubusercontent.com/AGenUI/AGenUI/refs/heads/main/docs/articles/index.json`
      returns 200
