### PR TITLE
feat(docs): publish the AGenUI Playground privacy policy via GitHub Pages

### DIFF
--- a/.github/workflows/pages-privacy.yml
+++ b/.github/workflows/pages-privacy.yml
@@ -1,0 +1,34 @@
+name: Pages - Privacy Policies
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/pages/**'
+      - '.github/workflows/pages-privacy.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-privacy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/pages
+      - name: Deploy privacy policies
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/pages/privacy/agenui-playground/index.html
+++ b/docs/pages/privacy/agenui-playground/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AGenUI Playground Privacy Policy</title>
+  <style>
+    body { margin: 0; background: #f5f7fa; color: #18202a; font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    main { max-width: 760px; margin: 48px auto; padding: 36px; background: white; border-radius: 18px; box-shadow: 0 12px 40px rgba(24, 32, 42, .08); }
+    h1, h2 { line-height: 1.25; }
+    h1 { margin-top: 0; }
+    a { color: #1769e0; }
+    .updated { color: #667180; }
+    @media (max-width: 820px) { main { margin: 0; min-height: 100vh; border-radius: 0; padding: 28px 22px; } }
+  </style>
+</head>
+<body>
+<main>
+  <h1>AGenUI Playground Privacy Policy</h1>
+  <p class="updated">Effective date: August 3, 2026</p>
+
+  <h2>Overview</h2>
+  <p>AGenUI Playground is a developer tool for viewing and editing declarative A2UI data. No account is required, and the app does not include advertising or cross-app tracking.</p>
+
+  <h2>Data collection</h2>
+  <p>AGenUI Playground does not collect personal information, analytics, advertising identifiers, precise location, contacts, photos, financial information, or health information. The app does not sell or share user data.</p>
+
+  <h2>Camera access</h2>
+  <p>Camera access is optional and is used only to scan a QR code that you choose to open. Camera frames are processed on the device and are not uploaded by AGenUI Playground.</p>
+
+  <h2>Local files and settings</h2>
+  <p>Edited JSON, runtime logs, and preferences may be stored in the app's local container. You can remove this data by deleting the app. Files that you explicitly export or share are controlled by the destination you select.</p>
+
+  <h2>Network requests</h2>
+  <p>Bundled examples work without an account. When you explicitly open a remote JSON, image, audio, video, or web URL, the app connects to the server identified by that URL. That server may receive standard request information such as your IP address and is governed by its own privacy policy. AGenUI does not operate those third-party servers.</p>
+
+  <h2>Children</h2>
+  <p>The app is intended as a developer tool and is not directed to children. It does not knowingly collect personal data from children.</p>
+
+  <h2>Changes and contact</h2>
+  <p>Material changes will be published on this page. For privacy questions, contact the AGenUI maintainers through the <a href="https://github.com/AGenUI/AGenUI/issues">AGenUI issue tracker</a>.</p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `docs/pages/privacy/agenui-playground/index.html` — privacy policy for the iOS Playground app.
- Add `.github/workflows/pages-privacy.yml` — deploys `docs/pages` to GitHub Pages on push to `main`, or on manual dispatch.

App Store Connect rejects a submission whose privacy policy URL is not publicly reachable. The Playground store metadata points at `https://agenui.github.io/AGenUI/privacy/agenui-playground/`, which currently returns 404 because the page was never hosted.

## Test plan
- [ ] Merge, then confirm the `Pages - Privacy Policies` workflow succeeds.
- [ ] Enable Pages with **GitHub Actions** as the source if it is not already enabled — `https://agenui.github.io/` currently 404s, so Pages appears to have never been turned on for this repository.
- [ ] Verify `curl -I https://agenui.github.io/AGenUI/privacy/agenui-playground/` returns HTTP 200.