### PR TITLE
fix(android): preserve text line-height on dynamic updates

### DIFF
--- a/platforms/android/src/main/java/com/amap/agenui/render/component/impl/TextComponent.java
+++ b/platforms/android/src/main/java/com/amap/agenui/render/component/impl/TextComponent.java
@@ -79,6 +79,8 @@ public class TextComponent extends A2UIComponent {
             return;
         }
 
+        boolean textChanged = false;
+
         // Handle text append
         if (changedProps.containsKey("textChunk")) {
             Object textValue = changedProps.get("textChunk");
@@ -87,6 +89,7 @@ public class TextComponent extends A2UIComponent {
                 // Incrementally append text
                 currentText.append(textChunk);
                 textView.setText(currentText.toString());
+                textChanged = true;
             }
         }
         // Handle text update (overwrite existing content)
@@ -95,15 +98,16 @@ public class TextComponent extends A2UIComponent {
             String text = extractTextValue(textValue);
             currentText = new StringBuilder(text);
             textView.setText(currentText.toString());
+            textChanged = true;
         }
 
-        // Apply custom styles (override variant preset styles)
-        if (changedProps.containsKey("styles")) {
+        // setText replaces the Spannable that carries metric-affecting styles such as
+        // CenteredLineHeightSpan. Reapply the full resolved style map after every text
+        // update so TextView's line boxes stay consistent with TextMeasurer/Yoga.
+        if (textChanged || changedProps.containsKey("styles")) {
             try {
-                Object stylesValue = changedProps.get("styles");
-                if (stylesValue instanceof Map) {
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> styles = (Map<String, Object>) stylesValue;
+                Map<String, Object> styles = extractStyles(this.properties);
+                if (styles != null && !styles.isEmpty()) {
                     applyStyles(styles);
                 }
             } catch (Exception e) {


### PR DESCRIPTION
## What

Reapply the resolved Text styles after every dynamic `text` or `textChunk` update on Android.

## Why

`TextView#setText` replaces the `Spannable` that carries `CenteredLineHeightSpan`. Previously, a data-bound Text component lost its rendered line-height after the first content refresh while Yoga continued to measure it with the configured line-height. This mismatch caused visible vertical movement in frequently refreshed text such as quote prices and changes.

## Impact

Dynamic Text now keeps Android rendering aligned with Yoga measurement, eliminating the vertical spacing jitter without changing the A2UI protocol.

## Validation

- `./gradlew compileDebugJavaWithJavac` (from `platforms/android`)
