### PR TITLE
feat(studio): add OrcaRouter as a preset provider

### DIFF
--- a/playground/studio/README.md
+++ b/playground/studio/README.md
@@ -21,7 +21,7 @@ So you get the same high-quality output as mounting the Skill into an AI coding 
 
 ## Features
 
-- **BYOK multi-model** — DeepSeek, Qwen (DashScope), GLM (Zhipu), Moonshot, MiniMax, OpenAI, Gemini, Anthropic, OpenRouter, plus any OpenAI-compatible endpoint.
+- **BYOK multi-model** — DeepSeek, Qwen (DashScope), GLM (Zhipu), Moonshot, MiniMax, OpenAI, Gemini, Anthropic, OpenRouter, OrcaRouter, plus any OpenAI-compatible endpoint.
 - **Real-time streaming** — generation streams over SSE with a live protocol preview.
 - **Reasoning mode** — a toggle enables reasoning for capable models (may increase generation time).
 - **Multi-turn refinement** — iterate on the generated protocol with follow-up prompts; the previous protocol is used as the baseline.
@@ -114,7 +114,7 @@ Each entry under `providers` is an OpenAI-compatible endpoint:
 | `model`      | Model name to call                                 |
 | `max_tokens` | Maximum tokens for the generation response         |
 
-The template ships with ready-to-fill entries for DeepSeek, Qwen, Moonshot, Zhipu (GLM), MiniMax, OpenAI, Gemini, Anthropic, and OpenRouter.
+The template ships with ready-to-fill entries for DeepSeek, Qwen, Moonshot, Zhipu (GLM), MiniMax, OpenAI, Gemini, Anthropic, OpenRouter, and OrcaRouter.
 
 ### Server
 

--- a/playground/studio/config.example.json
+++ b/playground/studio/config.example.json
@@ -54,6 +54,12 @@
       "api_key": "",
       "model": "anthropic/claude-sonnet-4",
       "max_tokens": 8192
+    },
+    "orcarouter": {
+      "base_url": "https://api.orcarouter.ai/v1",
+      "api_key": "",
+      "model": "openai/gpt-5.5",
+      "max_tokens": 8192
     }
   },
   "server": {

--- a/playground/studio/server/config.py
+++ b/playground/studio/server/config.py
@@ -73,6 +73,11 @@ PRESET_TEMPLATE: dict[str, dict[str, Any]] = {
         "model": "anthropic/claude-sonnet-4",
         "max_tokens": 8192,
     },
+    "orcarouter": {
+        "base_url": "https://api.orcarouter.ai/v1",
+        "model": "openai/gpt-5.5",
+        "max_tokens": 8192,
+    },
 }
 
 


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a ready-to-fill provider preset in AGenUI Studio. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `playground/studio/server/config.py`: registers `orcarouter` in `PRESET_TEMPLATE` (base URL `https://api.orcarouter.ai/v1`, default model `openai/gpt-5.5`)
- `playground/studio/config.example.json`: adds the `orcarouter` entry alongside the existing providers
- `playground/studio/README.md`: lists OrcaRouter in the BYOK providers and in the preset list

This mirrors how the OpenRouter preset is wired in this repo, so the settings dialog and config reference stay consistent for users.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. In Studio settings, select **OrcaRouter** and paste the key (or edit `~/.agenui/config.json`).
3. Pick a model id such as `openai/gpt-5.5`, `anthropic/claude-opus-4.8` or `z-ai/glm-5.2`.

## Verification

- `python -m py_compile` on `config.py` passes; `config.example.json` parses as valid JSON; `PRESET_TEMPLATE`/`_generate_default_config()` include the new provider.
- Live API: `POST https://api.orcarouter.ai/v1/chat/completions` with `model: openai/gpt-5.5` returned `200` and a normal completion.
