### PR TITLE
fix(harmony): add explicit type annotation for the NAPI parseColor result in StyleHelper to fix the arkts-no-any-unknown compile error

### DIFF
--- a/platforms/harmony/agenui/src/main/ets/agenui/custom/StyleHelper.ets
+++ b/platforms/harmony/agenui/src/main/ets/agenui/custom/StyleHelper.ets
@@ -67,7 +67,7 @@ export class StyleHelper {
     // fallback for environments where the native symbol is unavailable.
     try {
       if (typeof nativeModule.parseColor === 'function') {
-        const parsed = nativeModule.parseColor(raw);
+        const parsed: number | undefined = nativeModule.parseColor(raw);
         if (typeof parsed === 'number') {
           return parsed >>> 0;
         }


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build scripts
- [ ] Other (please describe)

## Affected Platform(s)

- [ ] Android
- [ ] iOS
- [ ] HarmonyOS
- [ ] C++ Core Engine
- [ ] Documentation / CI

## Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/AGenUI/AGenUI/blob/main/CONTRIBUTING.md) guide
- [ ] Code compiles without errors on affected platform(s)
- [ ] I have tested on relevant device(s) or simulator(s)
- [ ] Documentation updated (if applicable)